### PR TITLE
Add ld-* libs to shared library dependencies

### DIFF
--- a/cmd/ldd.go
+++ b/cmd/ldd.go
@@ -54,10 +54,6 @@ func NewLddCmd() *cobra.Command {
 			}
 			for _, dep := range dependencies {
 				if strings.HasPrefix(dep, tmpRoot) {
-					if strings.HasPrefix(filepath.Base(dep), "ld-") {
-						// don't link against ld itself
-						continue
-					}
 					files = append(files, strings.TrimPrefix(dep, tmpRoot))
 				}
 			}


### PR DESCRIPTION
If the ld-* lib on the node is not compatible with the libc version
coming in via bazeldnf, we have to use `ld-*` from the pulled in RPMs.
Otherwise we get linker errors.

Signed-off-by: Roman Mohr <rmohr@redhat.com>