### PR TITLE
Add an option to ignore packages and their dependencies

### DIFF
--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "github.com/rmohr/bazeldnf/cmd",
     visibility = ["//visibility:private"],
     deps = [
+        "//cmd/template",
         "//pkg/api",
         "//pkg/api/bazeldnf",
         "//pkg/bazel",

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"fmt"
+	"os"
 
+	"github.com/rmohr/bazeldnf/cmd/template"
 	"github.com/rmohr/bazeldnf/pkg/api/bazeldnf"
 	"github.com/rmohr/bazeldnf/pkg/reducer"
 	"github.com/rmohr/bazeldnf/pkg/repo"
@@ -65,13 +66,9 @@ func NewResolveCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Println("Installing:")
-			fmt.Println(install)
-			fmt.Println(len(install))
-			fmt.Println("Force-ignoring:")
-			fmt.Println(forceIgnored)
-			fmt.Println(len(forceIgnored))
-			logrus.Info("Done.")
+			if err := template.Render(os.Stdout, install, forceIgnored); err != nil {
+				return err
+			}
 			return nil
 		},
 	}

--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"os"
+
+	"github.com/rmohr/bazeldnf/cmd/template"
 	"github.com/rmohr/bazeldnf/pkg/bazel"
 	"github.com/rmohr/bazeldnf/pkg/reducer"
 	"github.com/rmohr/bazeldnf/pkg/repo"
@@ -57,7 +60,7 @@ func NewRpmTreeCmd() *cobra.Command {
 				return err
 			}
 			logrus.Info("Solving.")
-			install, _, _, err := solver.Resolve()
+			install, _, forceIgnored, err := solver.Resolve()
 			if err != nil {
 				return err
 			}
@@ -81,7 +84,9 @@ func NewRpmTreeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			logrus.Info("Done.")
+			if err := template.Render(os.Stdout, install, forceIgnored); err != nil {
+				return err
+			}
 
 			return nil
 		},

--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -19,6 +19,7 @@ type rpmtreeOpts struct {
 	buildfile        string
 	name             string
 	public           bool
+	forceIgnoreRegex []string
 }
 
 var rpmtreeopts = rpmtreeOpts{}
@@ -46,7 +47,7 @@ func NewRpmTreeCmd() *cobra.Command {
 			}
 			solver := sat.NewResolver(rpmtreeopts.nobest)
 			logrus.Info("Loading involved packages into the rpmtreer.")
-			err = solver.LoadInvolvedPackages(involved)
+			err = solver.LoadInvolvedPackages(involved, rpmtreeopts.forceIgnoreRegex)
 			if err != nil {
 				return err
 			}
@@ -56,7 +57,7 @@ func NewRpmTreeCmd() *cobra.Command {
 				return err
 			}
 			logrus.Info("Solving.")
-			install, _, err := solver.Resolve()
+			install, _, _, err := solver.Resolve()
 			if err != nil {
 				return err
 			}
@@ -94,6 +95,7 @@ func NewRpmTreeCmd() *cobra.Command {
 	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.workspace, "workspace", "w", "WORKSPACE", "Bazel workspace file")
 	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.buildfile, "buildfile", "b", "rpm/BUILD.bazel", "Build file for RPMs")
 	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.name, "name", "", "", "rpmtree rule name")
+	rpmtreeCmd.Flags().StringArrayVar(&rpmtreeopts.forceIgnoreRegex, "force-ignore-with-dependencies", []string{}, "Packages matching these regex patterns will not be installed. Allows force-removing unwanted dependencies. Be careful, this can lead to hidden missing dependencies.")
 	rpmtreeCmd.MarkFlagRequired("name")
 	return rpmtreeCmd
 }

--- a/cmd/template/BUILD.bazel
+++ b/cmd/template/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "template",
+    srcs = ["install.go"],
+    importpath = "github.com/rmohr/bazeldnf/cmd/template",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/api"],
+)

--- a/cmd/template/install.go
+++ b/cmd/template/install.go
@@ -1,0 +1,68 @@
+package template
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/rmohr/bazeldnf/pkg/api"
+)
+
+func Render(writer io.Writer, installed []*api.Package, forceIgnored []*api.Package) error {
+	totalDownloadSize := 0
+	totalInstallSize := 0
+
+	tabWriter := tabwriter.NewWriter(writer, 0, 8, 1, '\t', 0)
+	if _, err := fmt.Fprintln(tabWriter, "Package\tVersion\tSize\tDownload Size"); err != nil {
+		return fmt.Errorf("failed to write header: %v", err)
+	}
+	if _, err := fmt.Fprintln(tabWriter, "Installing:\t\t\t"); err != nil {
+		return fmt.Errorf("failed to write header: %v", err)
+	}
+	for _, pkg := range installed {
+		totalInstallSize += pkg.Size.Archive
+		totalDownloadSize += pkg.Size.Package
+		if _, err := fmt.Fprintf(tabWriter, " %v\t%v\t%s\t%s\n", pkg.Name, pkg.Version.String(), toReadableQuantity(pkg.Size.Archive), toReadableQuantity(pkg.Size.Package)); err != nil {
+			return fmt.Errorf("failed to write entry: %v", err)
+		}
+	}
+	if _, err := fmt.Fprintln(tabWriter, "Ignoring:\t\t\t"); err != nil {
+		return fmt.Errorf("failed to write header: %v", err)
+	}
+	for _, pkg := range forceIgnored {
+		if _, err := fmt.Fprintf(tabWriter, " %v\t%v\t%s\t%s\n", pkg.Name, pkg.Version.String(), toReadableQuantity(pkg.Size.Archive), toReadableQuantity(pkg.Size.Package)); err != nil {
+			return fmt.Errorf("failed to write entry: %v", err)
+		}
+	}
+	if _, err := fmt.Fprintln(tabWriter, "\t\t\t\nTransaction Summary:\t\t\t"); err != nil {
+		return fmt.Errorf("failed to write header: %v", err)
+	}
+	if _, err := fmt.Fprintf(tabWriter, "Installing %d Packages \t\t\t\n", len(installed)); err != nil {
+		return fmt.Errorf("failed to write header: %v", err)
+	}
+	if _, err := fmt.Fprintf(tabWriter, "Total download size: %s\t\t\t\n", toReadableQuantity(totalDownloadSize)); err != nil {
+		return fmt.Errorf("failed to write header: %v", err)
+	}
+	if _, err := fmt.Fprintf(tabWriter, "Total install size: %s\t\t\t\n", toReadableQuantity(totalInstallSize)); err != nil {
+		return fmt.Errorf("failed to write header: %v", err)
+	}
+	if err := tabWriter.Flush(); err != nil {
+		return fmt.Errorf("failed to flush table: %v", err)
+	}
+	return nil
+}
+
+func toReadableQuantity(bytes int) string {
+	if bytes > 1000*1000*1000 {
+		q := float64(bytes) / 1000 / 1000 / 1000
+		return fmt.Sprintf("%.2f G", q)
+	} else if bytes > 1000*1000 {
+		q := float64(bytes) / 1000 / 1000
+		return fmt.Sprintf("%.2f M", q)
+	} else if bytes > 1000 {
+		q := float64(bytes) / 1000
+		return fmt.Sprintf("%.2f K", q)
+	} else {
+		return fmt.Sprintf("%d", bytes)
+	}
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -233,9 +233,9 @@ type Package struct {
 	} `xml:"time"`
 	Size struct {
 		Text      string `xml:",chardata"`
-		Package   string `xml:"package,attr"`
-		Installed string `xml:"installed,attr"`
-		Archive   string `xml:"archive,attr"`
+		Package   int    `xml:"package,attr"`
+		Installed int    `xml:"installed,attr"`
+		Archive   int    `xml:"archive,attr"`
 	} `xml:"size"`
 	Location Location `xml:"location"`
 	Format   struct {

--- a/pkg/sat/sat_test.go
+++ b/pkg/sat/sat_test.go
@@ -27,11 +27,11 @@ func TestRecursive(t *testing.T) {
 			for i, _ := range repo.Packages {
 				packages = append(packages, &repo.Packages[i])
 			}
-			err = resolver.LoadInvolvedPackages(packages)
+			err = resolver.LoadInvolvedPackages(packages, nil)
 			g.Expect(err).ToNot(HaveOccurred())
 			err = resolver.ConstructRequirements([]string{pkg.Name})
 			g.Expect(err).ToNot(HaveOccurred())
-			_, _, err := resolver.Resolve()
+			_, _, _, err := resolver.Resolve()
 			if err != nil {
 				t.Fatalf("Failed to solve %s\n", pkg.Name)
 			}
@@ -1229,11 +1229,11 @@ func Test(t *testing.T) {
 			for i, _ := range repo.Packages {
 				packages = append(packages, &repo.Packages[i])
 			}
-			err = resolver.LoadInvolvedPackages(packages)
+			err = resolver.LoadInvolvedPackages(packages, nil)
 			g.Expect(err).ToNot(HaveOccurred())
 			err = resolver.ConstructRequirements(tt.requires)
 			g.Expect(err).ToNot(HaveOccurred())
-			install, _, err := resolver.Resolve()
+			install, _, _, err := resolver.Resolve()
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(pkgToString(install)).To(ConsistOf(tt.installs))
 		})
@@ -1359,7 +1359,7 @@ func TestNewResolver(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			resolver := NewResolver(tt.nobest)
-			err := resolver.LoadInvolvedPackages(tt.packages)
+			err := resolver.LoadInvolvedPackages(tt.packages, nil)
 			if err != nil {
 				t.Fail()
 			}
@@ -1368,7 +1368,7 @@ func TestNewResolver(t *testing.T) {
 				fmt.Println(err)
 				t.Fail()
 			}
-			install, exclude, err := resolver.Resolve()
+			install, exclude, _, err := resolver.Resolve()
 			g := NewGomegaWithT(t)
 			if tt.solvable {
 				g.Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Allow matching packages with regular expression which should be used
during to solution phase, but not install during the install phase.

Matched packages will be added to the dependency tree, but all their
requirements are wiped. Finally they are excluded from the list of
packages to install too.

Indirect dependencies of an ignored package can still be pulled in by
dependencies of other packages.

The regex can be passed in via `--force-ignore-with-dependencies`:

```bash
$ resolve --nobest -f centos-stream-release --force-ignore-with-dependencies '^kernel-' --force-ignore-with-dependencies '^python[3]{0,1}-' libguestfs
```

In addition a nicer install table will be printed for the `resolve` and the `rpmtree` commands. An example looks like this:

```bash
$ resolve --nobest -f centos-stream-release --force-ignore-with-dependencies '^kernel-' --force-ignore-with-dependencies '^python[3]{0,1}-' libguestfs
Package                                         Version                                         Size            Download Size
Installing:                                                                                                     
 glibc                                          0:2.28-161.el8                                  15.78 M         3.82 M
 [...]
 librados2                                      1:12.2.7-9.el8                                  12.86 M         3.04 M
Ignoring:                                                                                                       
 python3-pyyaml                                 0:3.12-12.el8                                   662.04 K        197.68 K
 [...]
 python3-dnf-plugins-core                       0:4.0.21-1.el8                                  777.86 K        234.27 K
                                                                                                                
Transaction Summary:                                                                                            
Installing 377 Packages                                                                                         
Total download size: 200.60 M                                                                                   
Total install size: 683.98 M

```
