### PR TITLE
Revert "Add ld-* libs to shared library dependencies"

### DIFF
--- a/cmd/ldd.go
+++ b/cmd/ldd.go
@@ -54,6 +54,10 @@ func NewLddCmd() *cobra.Command {
 			}
 			for _, dep := range dependencies {
 				if strings.HasPrefix(dep, tmpRoot) {
+					if strings.HasPrefix(filepath.Base(dep), "ld-") {
+						// don't link against ld itself
+						continue
+					}
 					files = append(files, strings.TrimPrefix(dep, tmpRoot))
 				}
 			}


### PR DESCRIPTION
This reverts commit 7db64a1cedfa6efcd034236dbcc15ebba9e84f94 which stopped filter out the linker. If we directly load the linker we potentially end up with two different linkers providing symbols which causes issues.