### PR TITLE
Generalize by removing most Fedora mentions

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -24,7 +24,7 @@ func NewInitCmd() *cobra.Command {
 		},
 	}
 
-	initCmd.Flags().StringVarP(&initopts.arch, "arch", "a", "x86_64", "target fedora architecture")
+	initCmd.Flags().StringVarP(&initopts.arch, "arch", "a", "x86_64", "target architecture")
 	initCmd.Flags().StringVarP(&initopts.fc, "fc", "", "", "target fedora core release")
 	initCmd.Flags().StringVarP(&initopts.out, "output", "o", "repo.yaml", "where to write the repository information")
 	err := initCmd.MarkFlagRequired("fc")

--- a/cmd/reduce.go
+++ b/cmd/reduce.go
@@ -14,13 +14,13 @@ import (
 )
 
 type reduceOpts struct {
-	in               []string
-	repofiles        []string
-	out              string
-	lang             string
-	nobest           bool
-	arch             string
-	fedoraBaseSystem string
+	in         []string
+	repofiles  []string
+	out        string
+	lang       string
+	nobest     bool
+	arch       string
+	baseSystem string
 }
 
 var reduceopts = reduceOpts{}
@@ -43,7 +43,7 @@ which allow reducing huge rpm repos to a smaller problem set for debugging, remo
 					return err
 				}
 			}
-			repo := reducer.NewRepoReducer(repos, reduceopts.in, reduceopts.lang, reduceopts.fedoraBaseSystem, reduceopts.arch, ".bazeldnf")
+			repo := reducer.NewRepoReducer(repos, reduceopts.in, reduceopts.lang, reduceopts.baseSystem, reduceopts.arch, ".bazeldnf")
 			logrus.Info("Loading packages.")
 			if err := repo.Load(); err != nil {
 				return err
@@ -72,9 +72,13 @@ which allow reducing huge rpm repos to a smaller problem set for debugging, remo
 
 	reduceCmd.Flags().StringArrayVarP(&reduceopts.in, "input", "i", nil, "primary.xml of the repository")
 	reduceCmd.Flags().StringVarP(&reduceopts.out, "output", "o", "debug.xml", "where to write the repository file")
-	reduceCmd.Flags().StringVarP(&reduceopts.fedoraBaseSystem, "fedora-base-system", "f", "fedora-release-container", "fedora base system to choose from (e.g. fedora-release-server, fedora-release-container, ...)")
+	reduceCmd.Flags().StringVar(&reduceopts.baseSystem, "basesystem", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")
 	reduceCmd.Flags().StringVarP(&reduceopts.arch, "arch", "a", "x86_64", "target fedora architecture")
 	reduceCmd.Flags().BoolVarP(&reduceopts.nobest, "nobest", "n", false, "allow picking versions which are not the newest")
 	reduceCmd.Flags().StringArrayVarP(&reduceopts.repofiles, "repofile", "r", []string{"repo.yaml"}, "repository information file. Can be specified multiple times. Will be used by default if no explicit inputs are provided.")
+	// deprecated options
+	reduceCmd.Flags().StringVarP(&reduceopts.baseSystem, "fedora-base-system", "f", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")
+	reduceCmd.Flags().MarkDeprecated("fedora-base-system", "use '--basesystem' instead")
+	reduceCmd.Flags().MarkShorthandDeprecated("f", "use '--basesystem' instead")
 	return reduceCmd
 }

--- a/cmd/reduce.go
+++ b/cmd/reduce.go
@@ -73,7 +73,7 @@ which allow reducing huge rpm repos to a smaller problem set for debugging, remo
 	reduceCmd.Flags().StringArrayVarP(&reduceopts.in, "input", "i", nil, "primary.xml of the repository")
 	reduceCmd.Flags().StringVarP(&reduceopts.out, "output", "o", "debug.xml", "where to write the repository file")
 	reduceCmd.Flags().StringVar(&reduceopts.baseSystem, "basesystem", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")
-	reduceCmd.Flags().StringVarP(&reduceopts.arch, "arch", "a", "x86_64", "target fedora architecture")
+	reduceCmd.Flags().StringVarP(&reduceopts.arch, "arch", "a", "x86_64", "target architecture")
 	reduceCmd.Flags().BoolVarP(&reduceopts.nobest, "nobest", "n", false, "allow picking versions which are not the newest")
 	reduceCmd.Flags().StringArrayVarP(&reduceopts.repofiles, "repofile", "r", []string{"repo.yaml"}, "repository information file. Can be specified multiple times. Will be used by default if no explicit inputs are provided.")
 	// deprecated options

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -17,7 +17,7 @@ type resolveOpts struct {
 	lang             string
 	nobest           bool
 	arch             string
-	fedoraBaseSystem string
+	baseSystem       string
 	repofiles        []string
 	forceIgnoreRegex []string
 }
@@ -40,7 +40,7 @@ func NewResolveCmd() *cobra.Command {
 					return err
 				}
 			}
-			repo := reducer.NewRepoReducer(repos, resolveopts.in, resolveopts.lang, resolveopts.fedoraBaseSystem, resolveopts.arch, ".bazeldnf")
+			repo := reducer.NewRepoReducer(repos, resolveopts.in, resolveopts.lang, resolveopts.baseSystem, resolveopts.arch, ".bazeldnf")
 			logrus.Info("Loading packages.")
 			if err := repo.Load(); err != nil {
 				return err
@@ -74,10 +74,14 @@ func NewResolveCmd() *cobra.Command {
 	}
 
 	resolveCmd.Flags().StringArrayVarP(&resolveopts.in, "input", "i", nil, "primary.xml of the repository")
-	resolveCmd.Flags().StringVarP(&resolveopts.fedoraBaseSystem, "fedora-base-system", "f", "fedora-release-container", "fedora base system to choose from (e.g. fedora-release-server, fedora-release-container, ...)")
+	resolveCmd.Flags().StringVar(&resolveopts.baseSystem, "basesystem", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")
 	resolveCmd.Flags().StringVarP(&resolveopts.arch, "arch", "a", "x86_64", "target fedora architecture")
 	resolveCmd.Flags().BoolVarP(&resolveopts.nobest, "nobest", "n", false, "allow picking versions which are not the newest")
 	resolveCmd.Flags().StringArrayVarP(&resolveopts.repofiles, "repofile", "r", []string{"repo.yaml"}, "repository information file. Can be specified multiple times. Will be used by default if no explicit inputs are provided.")
 	resolveCmd.Flags().StringArrayVar(&resolveopts.forceIgnoreRegex, "force-ignore-with-dependencies", []string{}, "Packages matching these regex patterns will not be installed. Allows force-removing unwanted dependencies. Be careful, this can lead to hidden missing dependencies.")
+	// deprecated options
+	resolveCmd.Flags().StringVarP(&resolveopts.baseSystem, "fedora-base-system", "f", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")
+	resolveCmd.Flags().MarkDeprecated("fedora-base-system", "use '--basesystem' instead")
+	resolveCmd.Flags().MarkShorthandDeprecated("f", "use '--basesystem' instead")
 	return resolveCmd
 }

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -75,7 +75,7 @@ func NewResolveCmd() *cobra.Command {
 
 	resolveCmd.Flags().StringArrayVarP(&resolveopts.in, "input", "i", nil, "primary.xml of the repository")
 	resolveCmd.Flags().StringVar(&resolveopts.baseSystem, "basesystem", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")
-	resolveCmd.Flags().StringVarP(&resolveopts.arch, "arch", "a", "x86_64", "target fedora architecture")
+	resolveCmd.Flags().StringVarP(&resolveopts.arch, "arch", "a", "x86_64", "target architecture")
 	resolveCmd.Flags().BoolVarP(&resolveopts.nobest, "nobest", "n", false, "allow picking versions which are not the newest")
 	resolveCmd.Flags().StringArrayVarP(&resolveopts.repofiles, "repofile", "r", []string{"repo.yaml"}, "repository information file. Can be specified multiple times. Will be used by default if no explicit inputs are provided.")
 	resolveCmd.Flags().StringArrayVar(&resolveopts.forceIgnoreRegex, "force-ignore-with-dependencies", []string{}, "Packages matching these regex patterns will not be installed. Allows force-removing unwanted dependencies. Be careful, this can lead to hidden missing dependencies.")

--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -16,7 +16,7 @@ type rpmtreeOpts struct {
 	lang             string
 	nobest           bool
 	arch             string
-	fedoraBaseSystem string
+	baseSystem       string
 	repofiles        []string
 	workspace        string
 	buildfile        string
@@ -38,7 +38,7 @@ func NewRpmTreeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			repoReducer := reducer.NewRepoReducer(repos, nil, rpmtreeopts.lang, rpmtreeopts.fedoraBaseSystem, rpmtreeopts.arch, ".bazeldnf")
+			repoReducer := reducer.NewRepoReducer(repos, nil, rpmtreeopts.lang, rpmtreeopts.baseSystem, rpmtreeopts.arch, ".bazeldnf")
 			logrus.Info("Loading packages.")
 			if err := repoReducer.Load(); err != nil {
 				return err
@@ -92,7 +92,7 @@ func NewRpmTreeCmd() *cobra.Command {
 		},
 	}
 
-	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.fedoraBaseSystem, "fedora-base-system", "f", "fedora-release-container", "fedora base system to choose from (e.g. fedora-release-server, fedora-release-container, ...)")
+	rpmtreeCmd.Flags().StringVar(&rpmtreeopts.baseSystem, "basesystem", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")
 	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.arch, "arch", "a", "x86_64", "target fedora architecture")
 	rpmtreeCmd.Flags().BoolVarP(&rpmtreeopts.nobest, "nobest", "n", false, "allow picking versions which are not the newest")
 	rpmtreeCmd.Flags().BoolVarP(&rpmtreeopts.public, "public", "p", true, "if the rpmtree rule should be public")
@@ -102,5 +102,9 @@ func NewRpmTreeCmd() *cobra.Command {
 	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.name, "name", "", "", "rpmtree rule name")
 	rpmtreeCmd.Flags().StringArrayVar(&rpmtreeopts.forceIgnoreRegex, "force-ignore-with-dependencies", []string{}, "Packages matching these regex patterns will not be installed. Allows force-removing unwanted dependencies. Be careful, this can lead to hidden missing dependencies.")
 	rpmtreeCmd.MarkFlagRequired("name")
+	// deprecated options
+	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.baseSystem, "fedora-base-system", "f", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")
+	rpmtreeCmd.Flags().MarkDeprecated("fedora-base-system", "use '--basesystem' instead")
+	rpmtreeCmd.Flags().MarkShorthandDeprecated("f", "use '--basesystem' instead")
 	return rpmtreeCmd
 }

--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -93,7 +93,7 @@ func NewRpmTreeCmd() *cobra.Command {
 	}
 
 	rpmtreeCmd.Flags().StringVar(&rpmtreeopts.baseSystem, "basesystem", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")
-	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.arch, "arch", "a", "x86_64", "target fedora architecture")
+	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.arch, "arch", "a", "x86_64", "target architecture")
 	rpmtreeCmd.Flags().BoolVarP(&rpmtreeopts.nobest, "nobest", "n", false, "allow picking versions which are not the newest")
 	rpmtreeCmd.Flags().BoolVarP(&rpmtreeopts.public, "public", "p", true, "if the rpmtree rule should be public")
 	rpmtreeCmd.Flags().StringArrayVarP(&rpmtreeopts.repofiles, "repofile", "r", []string{"repo.yaml"}, "repository information file. Can be specified multiple times. Will be used by default if no explicit inputs are provided.")

--- a/pkg/reducer/reducer.go
+++ b/pkg/reducer/reducer.go
@@ -174,11 +174,11 @@ func (r *RepoReducer) requires(p *api.Package) (wants []*api.Package) {
 	return wants
 }
 
-func NewRepoReducer(repos *bazeldnf.Repositories, repoFiles []string, lang string, fedoraRelease string, arch string, cachDir string) *RepoReducer {
+func NewRepoReducer(repos *bazeldnf.Repositories, repoFiles []string, lang string, baseSystem string, arch string, cachDir string) *RepoReducer {
 	return &RepoReducer{
 		packages:         nil,
 		lang:             lang,
-		implicitRequires: []string{fedoraRelease},
+		implicitRequires: []string{baseSystem},
 		repoFiles:        repoFiles,
 		provides:         map[string][]*api.Package{},
 		architectures:    []string{"noarch", arch},


### PR DESCRIPTION
Now that CentOS Stream support is fairly solid, hard-coded references to Fedora are increasingly out of place.