### PR TITLE
Prepare bazeldnf for creating sandboxes for bazel

### DIFF
--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "root.go",
         "rpm2tar.go",
         "rpmtree.go",
+        "sandbox.go",
         "tar2files.go",
         "verify.go",
     ],

--- a/cmd/ldd.go
+++ b/cmd/ldd.go
@@ -54,10 +54,6 @@ func NewLddCmd() *cobra.Command {
 			}
 			for _, dep := range dependencies {
 				if strings.HasPrefix(dep, tmpRoot) {
-					if strings.HasPrefix(filepath.Base(dep), "ld-") {
-						// don't link against ld itself
-						continue
-					}
 					files = append(files, strings.TrimPrefix(dep, tmpRoot))
 				}
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	rootCmd.AddCommand(NewSandboxCmd())
 	rootCmd.AddCommand(NewFetchCmd())
 	rootCmd.AddCommand(NewInitCmd())
 	rootCmd.AddCommand(NewRpmTreeCmd())

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rmohr/bazeldnf/pkg/rpm"
+	"github.com/spf13/cobra"
+)
+
+type sandboxOpts struct {
+	tar         string
+	sandboxRoot string
+	name        string
+}
+
+var sandboxopts = sandboxOpts{}
+
+func NewSandboxCmd() *cobra.Command {
+
+	sandboxCmd := &cobra.Command{
+		Use:   "sandbox",
+		Short: "Extract a set of RPMs to a specific location",
+		RunE: func(cmd *cobra.Command, objects []string) error {
+			rootDir := filepath.Join(sandboxopts.sandboxRoot, "sandbox", sandboxopts.name, "root")
+			if err := os.RemoveAll(rootDir); err != nil {
+				return fmt.Errorf("failed to do the initial cleanup on the sandbox: %v", err)
+			}
+			if err := os.MkdirAll(rootDir, os.ModePerm); err != nil {
+				return fmt.Errorf("failed to create the sandbox base directory: %v", err)
+			}
+			return rpm.Untar(rootDir, sandboxopts.tar)
+		},
+	}
+
+	sandboxCmd.Flags().StringVarP(&sandboxopts.tar, "input", "i", "", "Tar file with all dependencies")
+	sandboxCmd.Flags().StringVar(&sandboxopts.sandboxRoot, "sandbox", ".bazeldnf", "Root directory of the sandbox")
+	sandboxCmd.Flags().StringVarP(&sandboxopts.name, "name", "n", "default", "Sandbox name")
+	return sandboxCmd
+}

--- a/internal/bazeldnf.bzl
+++ b/internal/bazeldnf.bzl
@@ -43,6 +43,7 @@ _bazeldnf = rule(
             values = [
                 "",
                 "ldd",
+                "sandbox",
             ],
             default = "",
         ),

--- a/internal/bazeldnf.bzl
+++ b/internal/bazeldnf.bzl
@@ -1,6 +1,7 @@
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def _bazeldnf_impl(ctx):
+    transitive_dependencies = []
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     args = []
     if ctx.attr.command:
@@ -11,6 +12,7 @@ def _bazeldnf_impl(ctx):
         args += ["--rpmtree", ctx.attr.rpmtree]
     if ctx.file.tar:
         args += ["-i", ctx.file.tar.path]
+        transitive_dependencies += [ctx.attr.tar.files]
     for lib in ctx.attr.libs:
         args += [lib]
 
@@ -24,7 +26,10 @@ def _bazeldnf_impl(ctx):
         substitutions = substitutions,
         is_executable = True,
     )
-    runfiles = ctx.runfiles(files = [ctx.executable._bazeldnf])
+    runfiles = ctx.runfiles(
+        files = [ctx.executable._bazeldnf],
+        transitive_files = depset([], transitive = transitive_dependencies),
+    )
     return [DefaultInfo(
         files = depset([out_file]),
         runfiles = runfiles,


### PR DESCRIPTION
* Include `ld-*` libraries (this time here to stay)
* Add a `bazeldnf sandbox` command which works similar to untar but without `tar`.
* Fix a few untar issues for `bazeldnf sandbox`
* Allow running the `sandbox` command via the `bazeldnf` rule
* Properly pull in `rpmtree` dependencies in the `bazeldnf` rule which fixes an issue where outdated or not tar files were found.