### PR TITLE
[bug] Protect against pre bash 4.4 bug

### DIFF
--- a/internal/runner.bash.template
+++ b/internal/runner.bash.template
@@ -13,4 +13,4 @@ fi
 
 cd ${BUILD_WORKSPACE_DIRECTORY}
 
-"$bazeldnf_short_path" "${ARGS[@]}" "$@"
+"$bazeldnf_short_path" "${ARGS[@]+\"${ARGS[@]}\"}" "$@"


### PR DESCRIPTION
As described here https://stackoverflow.com/a/7577209 before bash 4.4 there's
a bug where if the array is empty then it's not properly initialize, which
leads to `set -u` trigger an unbounded variable error. Some Linux distributions
like CentOS7 bundle ancient versions like 4.2.46.

It's a minor bug, that's why I didn't created an Issue for it, but let me know if you need one