### PR TITLE
Follow protobuf branch s/master/main/ - otherwise we fail to fetch it

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,8 +35,8 @@ gazelle_dependencies()
 
 http_archive(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-master",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+    strip_prefix = "protobuf-main",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/main.zip"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")


### PR DESCRIPTION
Otherwise `make all` fails as follows:

ERROR: no such package '@com_google_protobuf//': java.io.IOException: Error extracting /home/maya/.cache/bazel/_bazel_maya/b86cf3d8b83d93fbb749bb3c64493c4b/external/com_google_protobuf/temp11108607076077878807/master.zip to /home/maya/.cache/bazel/_bazel_maya/b86cf3d8b83d93fbb749bb3c64493c4b/external/com_google_protobuf/temp11108607076077878807: Prefix "protobuf-master" was given, but not found in the archive. Here are possible prefixes for this archive: "protobuf-main".