### PR TITLE
Fix usage of bash arrays

### DIFF
--- a/internal/runner.bash.template
+++ b/internal/runner.bash.template
@@ -13,4 +13,4 @@ fi
 
 cd ${BUILD_WORKSPACE_DIRECTORY}
 
-"$bazeldnf_short_path" "${ARGS[@]+\"${ARGS[@]}\"}" "$@"
+"$bazeldnf_short_path" ${ARGS[@]+"${ARGS[@]}"} "$@"


### PR DESCRIPTION
After the recent changes to the way bash arrays are used, if you have a rule like

```
bazeldnf(
  name = "ldd_test",
  command = "ldd",
  ...
)
```

then calling

```
$ bazel run //:ldd_test
```

will result in

```
Error: unknown command "\"ldd" for "bazeldnf"
```

This is caused by the excessive number of (nested, escaped) quotes that are present in the expression. The new version follows the recommendations from https://stackoverflow.com/questions/7577052/ accurately and as such doesn't exhibit the problem.