### PR TITLE
Look for libraries in /usr/lib too

### DIFF
--- a/cmd/ldd.go
+++ b/cmd/ldd.go
@@ -48,7 +48,7 @@ func NewLddCmd() *cobra.Command {
 			}
 
 			files := []string{}
-			dependencies, err := ldd.Resolve(objects, filepath.Join(tmpRoot, "/usr/lib64"))
+			dependencies, err := ldd.Resolve(objects, []string{filepath.Join(tmpRoot, "/usr/lib64")})
 			if err != nil {
 				return err
 			}

--- a/cmd/ldd.go
+++ b/cmd/ldd.go
@@ -48,7 +48,7 @@ func NewLddCmd() *cobra.Command {
 			}
 
 			files := []string{}
-			dependencies, err := ldd.Resolve(objects, []string{filepath.Join(tmpRoot, "/usr/lib64")})
+			dependencies, err := ldd.Resolve(objects, []string{filepath.Join(tmpRoot, "/usr/lib64"), filepath.Join(tmpRoot, "/usr/lib")})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
On current aarch64 Linux versions such as CentOS Stream 9 and Fedora 36, `ld-linux-aarch64.so` is found in `/usr/lib` instead of `/usr/lib64`.