### PR TITLE
Fix overwrite of the tar header fields

### DIFF
--- a/pkg/rpm/tar.go
+++ b/pkg/rpm/tar.go
@@ -233,9 +233,10 @@ func CPIOToTarHeader(entry *cpio.CpioEntry) (*tar.Header, error) {
 	case cpio.S_ISREG:
 		if entry.Header.Nlink() > 1 && entry.Header.Filesize() == 0 {
 			tarHeader.Typeflag = tar.TypeLink
+			tarHeader.Size = 0
+		} else {
+			tarHeader.Typeflag = tar.TypeReg
 		}
-		tarHeader.Typeflag = tar.TypeReg
-		tarHeader.Size = 0
 	default:
 		return nil, fmt.Errorf("unknown file mode 0%o for %s",
 			entry.Header.Mode(), entry.Header.Filename())


### PR DESCRIPTION
Set proper Typeflag and Size when handling hardlinks and regular files.

Noticed that by visual code inspection: in the original code, `tarHeader.Typeflag` was overwritten with `tar.TypeReg` when handling an entry for a hardlink. A similar issue was with the `tarHeader.Size`: it was set to `0` for regular files.