### PR TITLE
Sanitize RPM names further

### DIFF
--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -308,5 +308,7 @@ func (r *tar2Files) SetFiles(dirs []string, fileMap map[string][]string) {
 func sanitize(name string) string {
 	name = strings.ReplaceAll(name, ":", "__")
 	name = strings.ReplaceAll(name, "+", "__plus__")
+	name = strings.ReplaceAll(name, "~", "__tilde__")
+	name = strings.ReplaceAll(name, "^", "__caret__")
 	return name
 }


### PR DESCRIPTION
Recent builds of passt ([list](https://copr.fedorainfracloud.org/coprs/sbrivio/passt/builds/)) use version numbers like

```
0^20221015.gb3f3591-1
0^20221014.gdf73bb1-1
0^20220929.g06aa26f-1
```

which is entirely correct from the RPM point of view but requires special care on the bazel front. While at it, deal with tilde too.