### PR TITLE
Deterministic URL sorting

### DIFF
--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -225,6 +225,10 @@ func (r *RPMRule) URLs() []string {
 			for _, expr := range urlsAttr.(*build.ListExpr).List {
 				urls = append(urls, expr.(*build.StringExpr).Value)
 			}
+			// Sort the URLs to keep the output deterministic.
+			sort.SliceStable(urls, func(i, j int) bool {
+				return urls[i] < urls[j]
+			})
 			return urls
 		}
 	}


### PR DESCRIPTION
This keeps output stable when regenerating WORKSPACE from scratch.

Our workflow always starts from scratch, this guarantees deterministic output: https://github.com/monogon-dev/monogon/blob/main/third_party/sandboxroot/regenerate.sh

Fixes https://github.com/rmohr/bazeldnf/issues/27