### PR TITLE
Escape URLs before adding them to bazel rules

### DIFF
--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -72,7 +72,10 @@ func NewRpmTreeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			bazel.AddRPMs(workspace, install, rpmtreeopts.arch)
+			err = bazel.AddRPMs(workspace, install, rpmtreeopts.arch)
+			if err != nil {
+				return err
+			}
 			bazel.AddTree(rpmtreeopts.name, build, install, rpmtreeopts.arch, rpmtreeopts.public)
 			bazel.PruneRPMs(build, workspace)
 			logrus.Info("Writing bazel files.")

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -3,6 +3,7 @@ package bazel
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -236,11 +237,15 @@ func (r *RPMRule) URLs() []string {
 	return nil
 }
 
-func (r *RPMRule) SetURLs(urls []string, href string) error {
+func (r *RPMRule) SetURLs(mirrors []string, href string) error {
 	urlsAttr := []build.Expr{}
-	for _, url := range urls {
-		u := strings.TrimSuffix(url, "/") + "/" + strings.TrimSuffix(href, "/")
-		urlsAttr = append(urlsAttr, &build.StringExpr{Value: u})
+	for _, mirror := range mirrors {
+		u, err := url.Parse(mirror)
+		if err != nil {
+			return err
+		}
+		u = u.JoinPath(href)
+		urlsAttr = append(urlsAttr, &build.StringExpr{Value: u.String()})
 	}
 	r.Rule.SetAttr("urls", &build.ListExpr{List: urlsAttr})
 	return nil


### PR DESCRIPTION
This will remove the need to have workarounds like https://github.com/kubevirt/kubevirt/commit/8052a7f3e30b221550bc8d49d74b77eaf5b4998a in the future.