### PR TITLE
Use pre-built binary for bazeldnf rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -76,3 +76,11 @@ rpm(
         "https://storage.googleapis.com/builddeps/2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6",
     ],
 )
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+http_file(
+    name = "bazeldnf-0.5.6-linux-amd64",
+    executable = True,
+    urls = [],  # TODO
+)

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -45,3 +45,12 @@ go_binary(
     embed = [":cmd_lib"],
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "prebuilt",
+    actual = select({
+        "@platforms://os:linux": "@bazeldnf-0.5.6-linux-amd64//file",
+        "//conditions:default": "cmd",
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/internal/bazeldnf.bzl
+++ b/internal/bazeldnf.bzl
@@ -52,7 +52,7 @@ _bazeldnf = rule(
         "libs": attr.string_list(),
         "tar": attr.label(allow_single_file = True),
         "_bazeldnf": attr.label(
-            default = "@bazeldnf//cmd:cmd",
+            default = "@bazeldnf//cmd:prebuilt",
             cfg = "host",
             executable = True,
         ),


### PR DESCRIPTION
Implements part 2 of 2 of #40.

Depends on #42 