### PR TITLE
implement to_macro as alternative destination for rpm rules

### DIFF
--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/rpm",
         "//pkg/sat",
         "//pkg/xattr",
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@com_github_sassoftware_go_rpmutils//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -8,6 +8,7 @@ import (
 
 type pruneOpts struct {
 	workspace string
+	toMacro   string
 	buildfile string
 }
 
@@ -19,19 +20,37 @@ func NewPruneCmd() *cobra.Command {
 		Use:   "prune",
 		Short: "prunes unused RPM dependencies",
 		RunE: func(cmd *cobra.Command, required []string) error {
-			workspace, err := bazel.LoadWorkspace(pruneopts.workspace)
-			if err != nil {
-				return err
-			}
 			build, err := bazel.LoadBuild(pruneopts.buildfile)
 			if err != nil {
 				return err
 			}
-			bazel.PruneRPMs(build, workspace)
-			err = bazel.WriteWorkspace(false, workspace, pruneopts.workspace)
-			if err != nil {
-				return err
+
+			if pruneopts.toMacro == "" {
+				workspace, err := bazel.LoadWorkspace(pruneopts.workspace)
+				if err != nil {
+					return err
+				}
+				bazel.PruneWorkspaceRPMs(build, workspace)
+				err = bazel.WriteWorkspace(false, workspace, pruneopts.workspace)
+				if err != nil {
+					return err
+				}
+			} else {
+				bzl, defname, err := bazel.ParseToMacro(pruneopts.toMacro)
+				if err != nil {
+					return err
+				}
+				bzlfile, err := bazel.LoadBzl(bzl)
+				if err != nil {
+					return err
+				}
+				bazel.PruneBzlfileRPMs(build, bzlfile, defname)
+				err = bazel.WriteBzl(false, bzlfile, bzl)
+				if err != nil {
+					return err
+				}
 			}
+
 			err = bazel.WriteBuild(false, build, pruneopts.buildfile)
 			if err != nil {
 				return err
@@ -42,6 +61,7 @@ func NewPruneCmd() *cobra.Command {
 	}
 
 	pruneCmd.Flags().StringVarP(&pruneopts.workspace, "workspace", "w", "WORKSPACE", "Bazel workspace file")
+	pruneCmd.Flags().StringVarP(&pruneopts.toMacro, "to_macro", "", "", "Tells bazeldnf to write the RPMs to a macro in the given bzl file instead of the WORKSPACE file.The expected format is: macroFile%defName")
 	pruneCmd.Flags().StringVarP(&pruneopts.buildfile, "buildfile", "b", "rpm/BUILD.bazel", "Build file for RPMs")
 	return pruneCmd
 }

--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"github.com/bazelbuild/buildtools/build"
 	"github.com/rmohr/bazeldnf/cmd/template"
 	"github.com/rmohr/bazeldnf/pkg/bazel"
 	"github.com/rmohr/bazeldnf/pkg/reducer"
@@ -19,6 +20,7 @@ type rpmtreeOpts struct {
 	baseSystem       string
 	repofiles        []string
 	workspace        string
+	toMacro          string
 	buildfile        string
 	name             string
 	public           bool
@@ -34,6 +36,8 @@ func NewRpmTreeCmd() *cobra.Command {
 		Short: "Writes a rpmtree rule and its rpmdependencies to bazel files",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, required []string) error {
+			writeToMacro := rpmtreeopts.toMacro != ""
+
 			repos, err := repo.LoadRepoFiles(rpmtreeopts.repofiles)
 			if err != nil {
 				return err
@@ -68,20 +72,49 @@ func NewRpmTreeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			var bzlfile *build.File
+			var bzl, defName string
+			if writeToMacro {
+				bzl, defName, err = bazel.ParseToMacro(rpmtreeopts.toMacro)
+				if err != nil {
+					return err
+				}
+				bzlfile, err = bazel.LoadBzl(bzl)
+				if err != nil {
+					return err
+				}
+			}
 			build, err := bazel.LoadBuild(rpmtreeopts.buildfile)
 			if err != nil {
 				return err
 			}
-			err = bazel.AddRPMs(workspace, install, rpmtreeopts.arch)
-			if err != nil {
-				return err
+			if writeToMacro {
+				err = bazel.AddBzlfileRPMs(bzlfile, defName, install, rpmtreeopts.arch)
+				if err != nil {
+					return err
+				}
+			} else {
+				err = bazel.AddWorkspaceRPMs(workspace, install, rpmtreeopts.arch)
+				if err != nil {
+					return err
+				}
 			}
 			bazel.AddTree(rpmtreeopts.name, build, install, rpmtreeopts.arch, rpmtreeopts.public)
-			bazel.PruneRPMs(build, workspace)
+			if writeToMacro {
+				bazel.PruneBzlfileRPMs(build, bzlfile, defName)
+			} else {
+				bazel.PruneWorkspaceRPMs(build, workspace)
+			}
 			logrus.Info("Writing bazel files.")
 			err = bazel.WriteWorkspace(false, workspace, rpmtreeopts.workspace)
 			if err != nil {
 				return err
+			}
+			if writeToMacro {
+				err = bazel.WriteBzl(false, bzlfile, bzl)
+				if err != nil {
+					return err
+				}
 			}
 			err = bazel.WriteBuild(false, build, rpmtreeopts.buildfile)
 			if err != nil {
@@ -101,6 +134,7 @@ func NewRpmTreeCmd() *cobra.Command {
 	rpmtreeCmd.Flags().BoolVarP(&rpmtreeopts.public, "public", "p", true, "if the rpmtree rule should be public")
 	rpmtreeCmd.Flags().StringArrayVarP(&rpmtreeopts.repofiles, "repofile", "r", []string{"repo.yaml"}, "repository information file. Can be specified multiple times. Will be used by default if no explicit inputs are provided.")
 	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.workspace, "workspace", "w", "WORKSPACE", "Bazel workspace file")
+	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.toMacro, "to_macro", "", "", "Tells bazeldnf to write the RPMs to a macro in the given bzl file instead of the WORKSPACE file.The expected format is: macroFile%defName")
 	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.buildfile, "buildfile", "b", "rpm/BUILD.bazel", "Build file for RPMs")
 	rpmtreeCmd.Flags().StringVar(&rpmtreeopts.name, "name", "", "rpmtree rule name")
 	rpmtreeCmd.Flags().StringArrayVar(&rpmtreeopts.forceIgnoreRegex, "force-ignore-with-dependencies", []string{}, "Packages matching these regex patterns will not be installed. Allows force-removing unwanted dependencies. Be careful, this can lead to hidden missing dependencies.")

--- a/pkg/bazel/testdata/orig.bzl
+++ b/pkg/bazel/testdata/orig.bzl
@@ -1,0 +1,5 @@
+def rpms():
+    rpm(
+        name = "test.rpm",
+        urls = ["http://something.rpm"],
+    )

--- a/pkg/bazel/testdata/pkgs.bzl
+++ b/pkg/bazel/testdata/pkgs.bzl
@@ -1,0 +1,33 @@
+def rpms():
+    rpm(
+        name = "a-0__1.2.3.myarch",
+        sha256 = "1234",
+        urls = [
+            "a/something/a",
+            "b/something/a",
+            "c/something/a",
+        ],
+    )
+    rpm(
+        name = "a-0__2.3.4.myarch",
+        sha256 = "1234",
+        urls = [
+            "e/something/a",
+            "f/something/a",
+            "g/something/a",
+        ],
+    )
+    rpm(
+        name = "b-0__2.3.4.myarch",
+        sha256 = "1234",
+        urls = [
+            "a/something/b",
+            "b/something/b",
+            "c/something/b",
+        ],
+    )
+
+    rpm(
+        name = "test.rpm",
+        urls = ["http://something.rpm"],
+    )


### PR DESCRIPTION
Closes #26.

This PR adds a new flag `--to_macro` (or `--from_macro` for verify), that uses a macro in a bzl file instead of the WORKSPACE for `rpm` rules.
The flag expects an expression of the form `path/to/file.bzl%name`, where the path to the bzl file and the name of the macro are separated by `%`.

I'm new to using bazel buildtools so I apologize for potentially weird choices.
