### PR TITLE
mark bazeldnf as pure go binary

### DIFF
--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -44,5 +44,6 @@ go_library(
 go_binary(
     name = "cmd",
     embed = [":cmd_lib"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Resolves #45

From @fmeum on Slack with regards to using bazeldnf as a provider for cross compiler toolchain sysroots:

> The Bazel DNF tool appears to be a Go tool. By default, on supported platforms, Go tools use a standard library built with a C compiler (cgo), which causes the cyclic dependency on the C++ toolchain.
> If @bazeldnf//cmd:cmd set pure = True on the go_binary rule, that may resolve this cyclic dependency.

While this issue is also fixed by shipping pre-compiled binaries, marking the binary as pure should be generally preferred since it has less dependencies on the host system (libc).

## TODO

- [ ] verify that there are no cyclic dependencies left when using this
