### PR TITLE
skip duplicate files in rpms

### DIFF
--- a/cmd/rpm2tar.go
+++ b/cmd/rpm2tar.go
@@ -44,6 +44,7 @@ func NewRpm2TarCmd() *cobra.Command {
 
 			tarWriter := tar.NewWriter(tarStream)
 			defer tarWriter.Close()
+			collector := rpm.NewCollector()
 			if len(rpm2taropts.input) != 0 {
 				directoryTree, err := order.TreeFromRPMs(rpm2taropts.input)
 				if err != nil {
@@ -62,7 +63,7 @@ func NewRpm2TarCmd() *cobra.Command {
 								Typeflag: tar.TypeSymlink,
 								Name:     k,
 								Linkname: v,
-								Mode:     0777,
+								Mode:     0o777,
 							},
 						},
 					)
@@ -80,13 +81,13 @@ func NewRpm2TarCmd() *cobra.Command {
 						return fmt.Errorf("could not open rpm at %s: %v", i, err)
 					}
 					defer rpmStream.Close()
-					err = rpm.RPMToTar(rpmStream, tarWriter, true, cap, rpm2taropts.selinuxLabels)
+					err = collector.RPMToTar(rpmStream, tarWriter, true, cap, rpm2taropts.selinuxLabels)
 					if err != nil {
 						return fmt.Errorf("could not convert rpm at %s: %v", i, err)
 					}
 				}
 			} else {
-				err := rpm.RPMToTar(rpmStream, tarWriter, false, cap, rpm2taropts.selinuxLabels)
+				err := collector.RPMToTar(rpmStream, tarWriter, false, cap, rpm2taropts.selinuxLabels)
 				if err != nil {
 					return fmt.Errorf("could not convert rpm : %v", err)
 				}

--- a/pkg/rpm/tar.go
+++ b/pkg/rpm/tar.go
@@ -15,7 +15,17 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func RPMToTar(rpmReader io.Reader, tarWriter *tar.Writer, noSymlinksAndDirs bool, capabilities map[string][]string, selinuxLabels map[string]string) error {
+type Collector struct {
+	createdPaths map[string]struct{}
+}
+
+func NewCollector() *Collector {
+	return &Collector{
+		createdPaths: make(map[string]struct{}),
+	}
+}
+
+func (c *Collector) RPMToTar(rpmReader io.Reader, tarWriter *tar.Writer, noSymlinksAndDirs bool, capabilities map[string][]string, selinuxLabels map[string]string) error {
 	rpm, err := rpmutils.ReadRpm(rpmReader)
 	if err != nil {
 		return fmt.Errorf("failed to read rpm: %s", err)
@@ -24,7 +34,7 @@ func RPMToTar(rpmReader io.Reader, tarWriter *tar.Writer, noSymlinksAndDirs bool
 	if err != nil {
 		return fmt.Errorf("failed to open the payload reader: %s", err)
 	}
-	return Tar(payloadReader, tarWriter, noSymlinksAndDirs, capabilities, selinuxLabels)
+	return Tar(payloadReader, tarWriter, noSymlinksAndDirs, capabilities, selinuxLabels, c.createdPaths)
 }
 
 func RPMToCPIO(rpmReader io.Reader) (*cpio.CpioStream, error) {

--- a/pkg/rpm/tar_test.go
+++ b/pkg/rpm/tar_test.go
@@ -48,7 +48,8 @@ func TestRPMToTar(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			defer tarWriter.Close()
 
-			err = RPMToTar(f, tar.NewWriter(tarWriter), false, nil, nil)
+			collector := NewCollector()
+			err = collector.RPMToTar(f, tar.NewWriter(tarWriter), false, nil, nil)
 			g.Expect(err).ToNot(HaveOccurred())
 			tarWriter.Close()
 
@@ -124,8 +125,9 @@ func TestTar2Files(t *testing.T) {
 			defer pipeReader.Close()
 			defer pipeWriter.Close()
 
+			collector := NewCollector()
 			go func() {
-				_ = RPMToTar(f, tar.NewWriter(pipeWriter), false, nil, nil)
+				_ = collector.RPMToTar(f, tar.NewWriter(pipeWriter), false, nil, nil)
 				pipeWriter.Close()
 			}()
 


### PR DESCRIPTION
Fixes #47

<strike>While this fixes my immediate issue, it's not very clean to pass around a map that is filled with state between invocations of `Tar`. The function was quite functional before.
Happy to refactor this to be cleaner. Just not quite sure where to go.</strike>

I can stay on this commit for the time being so there is no reason to rush merging this.