### PR TITLE
Update README to reflect the golang dependency drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,27 +79,23 @@ rpmtree(
 
 The bazeldnf repository needs to be added  to your `WORKSPACE`:
 
+<!-- install_start -->
 ```python
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazeldnf",
-    sha256 = "74f977ab8f13e466168ff0c80322bcb665db9f79d1bc497c742f9512737b91ea",
-    strip_prefix = "bazeldnf-0.0.1",
+    sha256 = "8dcd8908d444d230192bba6965cfa7477554cc991da86b2b68aae956645c3d5e",
     urls = [
-        "https://github.com/rmohr/bazeldnf/archive/v0.0.1.tar.gz",
+        "https://github.com/rmohr/bazeldnf/releases/download/v0.5.6-rc1/bazeldnf-v0.5.6-rc1.tar.gz",
     ],
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@bazeldnf//:deps.bzl", "bazeldnf_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains()
 
 bazeldnf_dependencies()
 ```
+<!-- install_end -->
 
 Define the `bazeldnf` executable rule in your `BUILD.bazel` file:
 ```python

--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -73,7 +73,9 @@ git archive --format tar.gz HEAD >./dist/bazeldnf-${VERSION}.tar.gz
 DIGEST=$(sha256sum dist/bazeldnf-${VERSION}.tar.gz | cut -d " " -f 1)
 
 cat <<EOT >>./dist/releasenote.txt
-\`\`\`
+\`\`\`python
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "bazeldnf",
     sha256 = "${DIGEST}",
@@ -81,5 +83,14 @@ http_archive(
         "https://github.com/rmohr/bazeldnf/releases/download/${VERSION}/bazeldnf-${VERSION}.tar.gz",
     ],
 )
+
+load("@bazeldnf//:deps.bzl", "bazeldnf_dependencies")
+
+bazeldnf_dependencies()
 \`\`\`
 EOT
+
+lead='^<!-- install_start -->$'
+tail='^<!-- install_end -->$'
+sed -e "/$lead/,/$tail/{ /$lead/{p; r dist/releasenote.txt
+        }; /$tail/p; d }" README.md


### PR DESCRIPTION
Since `deps.bzl` now contains prebuilt images, there is no need to set up a golang toolchain to use bazeldnf from within bazel.

This PR will anso ensure that future release runs will also update the README.md file with the correct installation instructions.