### PR TITLE
Support release candidate bulding properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazeldnf",
-    sha256 = "214289f6a7b79346f3fe714070661624143341066b7fc57169a9b89b412ead22",
+    sha256 = "9dfd5ab882cae4ff9e2a7c1352c05949fa0c175af6b4103b19db48657e6da8b8",
     urls = [
-        "https://github.com/rmohr/bazeldnf/releases/download/v0.5.7-rc0/bazeldnf-v0.5.7-rc0.tar.gz",
+        "https://github.com/rmohr/bazeldnf/releases/download/v0.5.6/bazeldnf-v0.5.6.tar.gz",
     ],
 )
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ rpmtree(
 )
 ```
 
-### Running bazeldnf with bazel
+## Running bazeldnf with bazel
 
 The bazeldnf repository needs to be added  to your `WORKSPACE`:
 

--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -106,9 +106,13 @@ bazeldnf_dependencies()
 \`\`\`
 EOT
 
-lead='^<!-- install_start -->$'
-tail='^<!-- install_end -->$'
-sed -i -e "/$lead/,/$tail/{ /$lead/{p; r dist/releasenote.txt
+# Only update the README if we don't build a release candidate
+if [[ "${VERSION}" != *"-rc"* ]]; then
+
+	lead='^<!-- install_start -->$'
+	tail='^<!-- install_end -->$'
+	sed -i -e "/$lead/,/$tail/{ /$lead/{p; r dist/releasenote.txt
         }; /$tail/p; d }" README.md
 
-git commit -a -m "Bump install instructions for readme in ${VERSION}"
+	git commit -a -m "Bump install instructions for readme in ${VERSION}"
+fi


### PR DESCRIPTION
If a release candidate is built (`-rc` in the version string), then don't update the README.md install instructions, so that people always see the last valid release.