### PR TITLE
RPM rule integrity and mnemonics

### DIFF
--- a/internal/rpm.bzl
+++ b/internal/rpm.bzl
@@ -27,9 +27,10 @@ def _rpm_impl(ctx):
         downloaded_file_path = "downloaded"
         download_path = ctx.path("rpm/" + downloaded_file_path)
         download_info = ctx.download(
-            ctx.attr.urls,
-            "rpm/" + downloaded_file_path,
-            ctx.attr.sha256,
+            url = ctx.attr.urls,
+            output = "rpm/" + downloaded_file_path,
+            sha256 = ctx.attr.sha256,
+            integrity = ctx.attr.integrity,
         )
     else:
         fail("urls must be specified")
@@ -41,6 +42,7 @@ _rpm_attrs = {
     "urls": attr.string_list(),
     "strip_prefix": attr.string(),
     "sha256": attr.string(),
+    "integrity": attr.string(),
 }
 
 rpm = repository_rule(

--- a/internal/rpmtree.bzl
+++ b/internal/rpmtree.bzl
@@ -44,6 +44,7 @@ def _rpm2tar_impl(ctx):
         inputs = ctx.files.rpms,
         outputs = [out],
         arguments = args,
+        mnemonic = "Rpm2Tar",
         progress_message = "Converting %s to tar" % ctx.label.name,
         executable = ctx.executable._bazeldnf,
     )
@@ -61,6 +62,7 @@ def _tar2files_impl(ctx):
         inputs = ctx.files.tar,
         outputs = ctx.outputs.out,
         arguments = args,
+        mnemonic = "Tar2Files",
         progress_message = "Extracting files",
         executable = ctx.executable._bazeldnf,
     )


### PR DESCRIPTION
Two small changes:

## Add "integrity" as alternative for "sha256" in rpm rule

This is an alternative format for specifying the expected hash. It specifies the expected checksum in [Subresource Integrity format](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) of the file downloaded.

## Add mnemonics to rpm2tar and tar2files

When using remote cache in Bazel, some IO intensive actions are slower when using the remote cache (vs always redoing the action locally). This behavior can be controlled using the flag `--modify_execution_info`.
See also: https://blog.aspect.dev/bazelrc-flags
