### PR TITLE
Reconfigure the RPM URLs if checksum changed.

### DIFF
--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -122,14 +122,17 @@ func AddWorkspaceRPMs(workspace *build.File, pkgs []*api.Package, arch string) e
 			rpms[pkgName] = rule
 		}
 		rule.SetName(pkgName)
-		rule.SetSHA256(pkg.Checksum.Text)
 		urls := rule.URLs()
-		if len(urls) == 0 {
+		// Configure/re-configure the URLs when
+		// 1) no URLs are set, or
+		// 2) the checksum changed.
+		if len(urls) == 0 || (rule.SHA256() != pkg.Checksum.Text) {
 			err := rule.SetURLs(pkg.Repository.Mirrors, pkg.Location.Href)
 			if err != nil {
 				return err
 			}
 		}
+		rule.SetSHA256(pkg.Checksum.Text)
 	}
 
 	rules := []*RPMRule{}

--- a/pkg/bazel/testdata/WORKSPACE
+++ b/pkg/bazel/testdata/WORKSPACE
@@ -11,3 +11,12 @@ rpm(
     name = "test.rpm",
     urls = ["http://something.rpm"],
 )
+
+rpm(
+    name = "a-0__2.3.4.myarch",
+    sha256 = "0000",
+    urls = [
+        "old/url/1",
+        "old/url/2",
+    ],
+)


### PR DESCRIPTION
Currently if for some reason the RPM entry changed, bazeldnf won't reconfigure the URLs if they are already set. While this behavior aims to cover cases like mirror urls getting added out of band, there is a case where the URLs are messed up and do match the checksum. Therefore with this change it reconfigures the RPM URLs when the checksum changed.