### PR TITLE
Fix tar2files bazel integration

### DIFF
--- a/internal/rpmtree.bzl
+++ b/internal/rpmtree.bzl
@@ -126,7 +126,7 @@ def tar2files(**kwargs):
             name = basename + k
             files = []
             for file in v:
-                files = files + [basename + "/" + file]
+                files = files + [name + "/" + file]
             _tar2files(
                 name = name,
                 prefix = k,


### PR DESCRIPTION
The names that are passed to bazeldnf need to include the directory part too, otherwise having two files with the same name in different paths triggers a failure:

```
+ bazel run --config x86_64 //rpm:sandbox_s390x
...
Error in _tar2files: generated file 'cc-toolchain_s390x/errno.h'
in rule 'cc-toolchain_s390x/usr/include/asm' conflicts with
existing generated file from rule 'cc-toolchain_s390x/usr/include'
```
