### PR TITLE
Enable support for s390x architecture

### DIFF
--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -55,6 +55,7 @@ alias(
         "@io_bazel_rules_go//go/platform:linux_arm64": "@bazeldnf-linux-arm64//file:downloaded",
         "@io_bazel_rules_go//go/platform:linux_ppc64": "@bazeldnf-linux-ppc64//file:downloaded",
         "@io_bazel_rules_go//go/platform:linux_ppc64le": "@bazeldnf-linux-ppc64le//file:downloaded",
+        "@io_bazel_rules_go//go/platform:linux_s390x": "@bazeldnf-linux-s390x//file:downloaded",
         "@io_bazel_rules_go//go/platform:darwin_amd64": "@bazeldnf-darwin-amd64//file:downloaded",
         "@io_bazel_rules_go//go/platform:darwin_arm64": "@bazeldnf-darwin-arm64//file:downloaded",
         "//conditions:default": "cmd",

--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -42,6 +42,7 @@ build_arch darwin amd64
 build_arch darwin arm64
 build_arch linux ppc64
 build_arch linux ppc64le
+build_arch linux s390x
 
 cat <<EOT >./deps.bzl
 load(
@@ -79,6 +80,7 @@ write_arch darwin amd64
 write_arch darwin arm64
 write_arch linux ppc64
 write_arch linux ppc64le
+write_arch linux s390x
 
 git commit -a -m "Bump prebuilt binary references for ${VERSION}"
 


### PR DESCRIPTION
Add s390x to build targets.

I would like to add s390x support for this project, as it is a required dependency to [enable kubevirt](https://github.com/kubevirt/kubevirt/pull/10490) for s390x.

There is not really anything else needed to be done for this. I did not find any tests or CI that would need changes.

Please let me know if there are any other required changes that i missed or if there are any question.