### PR TITLE
Revert "Fix tar2files bazel integration"

### DIFF
--- a/internal/rpmtree.bzl
+++ b/internal/rpmtree.bzl
@@ -126,7 +126,7 @@ def tar2files(**kwargs):
             name = basename + k
             files = []
             for file in v:
-                files = files + [name + "/" + file]
+                files = files + [basename + "/" + file]
             _tar2files(
                 name = name,
                 prefix = k,


### PR DESCRIPTION
Reverts rmohr/bazeldnf#66

Potential candidate to fix #69.