### PR TITLE
WIP: bump to bazel6

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -8,9 +8,26 @@ on:
 
 jobs:
 
+  # TODO: rename to build-bazel-6 once we move into bazel 7 as the default, to be deprecated by Dec 2025
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: bazelbuild/setup-bazelisk@v1
     - run: bazel build //... && bazel test //...
+
+  # TODO: deprecate by Jan 2025 https://bazel.build/release
+  build-bazel-5:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: bazelbuild/setup-bazelisk@v1
+    - run: export USE_BAZEL_VERSION=5.x && bazel build //... && bazel test //...
+
+  # TODO: rename to build once we move into bazel 7 as the default
+  build-bazel-7:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: bazelbuild/setup-bazelisk@v1
+    - run: export USE_BAZEL_VERSION=6.x && bazel build //... && bazel test //...


### PR DESCRIPTION
This PR will be an enabler so we can adopt bzlmod, but in order to simplify the process let's first
do a bazel upgrade.

Changes:
* Adding CI to build against the latest 3 LTS versions