### PR TITLE
Remove unused RPMReader method

### DIFF
--- a/pkg/rpm/tar.go
+++ b/pkg/rpm/tar.go
@@ -49,18 +49,6 @@ func RPMToCPIO(rpmReader io.Reader) (*cpio.CpioStream, error) {
 	return cpio.NewCpioStream(payloadReader), nil
 }
 
-func RPMReader(rpmReader io.Reader, tarWriter *tar.Writer) error {
-	rpm, err := rpmutils.ReadRpm(rpmReader)
-	if err != nil {
-		return fmt.Errorf("failed to read rpm: %s", err)
-	}
-	payloadReader, err := rpm.RawUncompressedRPMPayloadReader()
-	if err != nil {
-		return fmt.Errorf("failed to open the payload reader: %s", err)
-	}
-	return cpio.Tar(payloadReader, tarWriter)
-}
-
 func PrefixFilter(prefix string, reader *tar.Reader, files []string) error {
 	prefix = strings.TrimPrefix(prefix, ".")
 


### PR DESCRIPTION
This code looks like it was intended to use the tar file implementation in the go-rpmutils PR that this repo is using, but the internal tar implementation never migrated to this.  As of now, this code is never used anywhere and can be safely removed