### PR TITLE
Add .netrc support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,6 +32,7 @@ use_repo(
     "com_github_adrg_xdg",
     "com_github_bazelbuild_buildtools",
     "com_github_crillab_gophersat",
+    "com_github_jdx_go_netrc",
     "com_github_onsi_gomega",
     "com_github_sassoftware_go_rpmutils",
     "com_github_sirupsen_logrus",

--- a/README.md
+++ b/README.md
@@ -263,6 +263,16 @@ The lock file JSON format is as follows:
 
 ```
 
+### Authentication
+
+During the build, downloading the resolved rpm files is handled by Bazel and authentication is also handled by Bazel.
+By default, Bazel will read the `.netrc` file, but more advanced mechanisms, such as the credential helper are also
+available.
+
+During dependency resolution authentication is handled by the bazeldnf command. At the moment only `.netrc` basic auth
+is supported. Credentials will be read from the file indicated by the `NETRC` environment variable if it is set,
+otherwise the `~/.netrc` file will be read.
+
 ### Dependency resolution limitations
 
 ##### Missing features

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,10 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
-require github.com/bazelbuild/rules_go v0.52.0
+require (
+	github.com/bazelbuild/rules_go v0.52.0
+	github.com/jdx/go-netrc v1.0.0
+)
 
 require (
 	github.com/adrg/xdg v0.5.3

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,14 @@ github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/Z
 github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jdx/go-netrc v1.0.0 h1:QbLMLyCZGj0NA8glAhxUpf1zDg6cxnWgMBbjq40W0gQ=
+github.com/jdx/go-netrc v1.0.0/go.mod h1:Gh9eFQJnoTNIRHXl2j5bJXA1u84hQWJWgGh569zF3v8=
 github.com/klauspost/compress v1.11.1 h1:bPb7nMRdOZYDrpPMTA3EInUQrdgoBinqUuSwlGdKDdE=
 github.com/klauspost/compress v1.11.1/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/onsi/ginkgo/v2 v2.22.1 h1:QW7tbJAUDyVDVOM5dFa7qaybo+CRfR7bemlQUN6Z8aM=
 github.com/onsi/ginkgo/v2 v2.22.1/go.mod h1:S6aTpoRsSq2cZOd+pssHAlKW/Q/jZt6cPrPlnj4a1xM=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
@@ -72,8 +78,9 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.1 h1:yBPeRvTftaleIgM3PZ/WBIZ7XM/eEYAaEyCwvyjq/gk=
 google.golang.org/protobuf v1.36.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/repo/BUILD.bazel
+++ b/pkg/repo/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/api/bazeldnf",
         "//pkg/rpm",
         "@com_github_adrg_xdg//:xdg",
+        "@com_github_jdx_go_netrc//:go-netrc",
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_spf13_cobra//:cobra",
         "@io_k8s_sigs_yaml//:yaml",

--- a/pkg/repo/fetch.go
+++ b/pkg/repo/fetch.go
@@ -272,18 +272,15 @@ func getNetrc() (*netrc.Netrc, error) {
 		if err != nil {
 			return nil, fmt.Errorf("getting current user: %w", err)
 		}
-		netrcPath = filepath.Join(usr.HomeDir, ".netrc")
+		homeNetrc := filepath.Join(usr.HomeDir, ".netrc")
+		_, err = os.Stat(homeNetrc)
+		if err == nil {
+			netrcPath = homeNetrc
+		}
 	}
 
 	if netrcPath != "" {
-		n, err := netrcCache.Read(netrcPath)
-		if err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
-				log.Warnf("Error reading netrc from %s: %v", netrcPath, err)
-			}
-			return nil, nil
-		}
-		return n, nil
+		return netrcCache.Read(netrcPath)
 	}
 	return nil, nil
 }


### PR DESCRIPTION
This is to support something like an internal mirror (such as Artifactory).
It's possible to use an one by hand-crafting a `repo.yaml` file, but things get tricky if such a mirror requires authentication.
This adds support for basic auth driven by a .netrc file.