### PR TITLE
Fix name collision with tar2files command

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -67,7 +67,7 @@ tar2files(
     files = {
         "/usr/lib64": [
             "libvirt.so.0",
-            "libvirt.so.0.6001.0",
+            "libvirt.so.0.11000.0",
         ],
     },
     tar = ":something",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -57,8 +57,8 @@ bazeldnf(
 rpmtree(
     name = "something",
     rpms = [
-        "@libvirt-libs-6.1.0-2.fc32.x86_64.rpm//rpm",
-        "@libvirt-devel-6.1.0-2.fc32.x86_64.rpm//rpm",
+        "@libvirt-libs-11.0.0-1.fc42.x86_64.rpm//rpm",
+        "@libvirt-devel-11.0.0-1.fc42.x86_64.rpm//rpm",
     ],
 )
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ processed in any way.  They can be added to your `WORKSPACE` file like this:
 load("@bazeldnf//bazeldnf:deps.bzl", "rpm")
 
 rpm(
-    name = "libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-    sha256 = "2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6",
+    name = "libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
+    sha256 = "aac272a2ace134b5ef60a41e6624deb24331e79c76699ef6cef0dca22d94ac7e",
     urls = [
-        "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/l/libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6",
+        "https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
     ],
 )
 ```
@@ -34,8 +33,8 @@ load("@bazeldnf//bazeldnf:defs.bzl", "rpmtree")
 rpmtree(
     name = "rpmarchive",
     rpms = [
-        "@libvirt-libs-6.1.0-2.fc32.x86_64.rpm//rpm",
-        "@libvirt-devel-6.1.0-2.fc32.x86_64.rpm//rpm",
+        "@libvirt-libs-11.0.0-1.fc42.x86_64.rpm//rpm",
+        "@libvirt-devel-11.0.0-1.fc42.x86_64.rpm//rpm",
     ],
 )
 ```
@@ -61,8 +60,8 @@ privileged ports:
 rpmtree(
     name = "rpmarchive",
     rpms = [
-        "@libvirt-libs-6.1.0-2.fc32.x86_64.rpm//rpm",
-        "@libvirt-devel-6.1.0-2.fc32.x86_64.rpm//rpm",
+        "@libvirt-libs-11.0.0-1.fc42.x86_64.rpm//rpm",
+        "@libvirt-devel-11.0.0-1.fc42.x86_64.rpm//rpm",
     ],
     symlinks = {
         "/var/run": "../run",

--- a/e2e/bazel-bzlmod-lock-file/BUILD.bazel
+++ b/e2e/bazel-bzlmod-lock-file/BUILD.bazel
@@ -9,8 +9,8 @@ rpmtree(
     name = "something",
     rpms = [
         "@bazeldnf-rpms//libvirt-libs",
-        "@bazeldnf-rpms//libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-        "@rpms-with-no-name-attribute//libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
+        "@bazeldnf-rpms//libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
+        "@rpms-with-no-name-attribute//libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
     ],
 )
 
@@ -19,7 +19,7 @@ tar2files(
     files = {
         "/usr/lib64": [
             "libvirt.so.0",
-            "libvirt.so.0.6001.0",
+            "libvirt.so.0.11000.0",
         ],
     },
     tar = ":something",

--- a/e2e/bazel-bzlmod-lock-file/rpms-with-no-name-attribute.json
+++ b/e2e/bazel-bzlmod-lock-file/rpms-with-no-name-attribute.json
@@ -1,12 +1,10 @@
 {
     "rpms": [
         {
-            "sha256": "3a0a3d88c6cb90008fbe49fe05e7025056fb9fa3a887c4a78f79e63f8745c845",
+            "sha256": "aac272a2ace134b5ef60a41e6624deb24331e79c76699ef6cef0dca22d94ac7e",
             "urls": [
-                "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/l/libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
-                "https://storage.googleapis.com/builddeps/3a0a3d88c6cb90008fbe49fe05e7025056fb9fa3a887c4a78f79e63f8745c845"
+		"https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm"
             ]
-
         }
     ]
 }

--- a/e2e/bazel-bzlmod-lock-file/rpms.json
+++ b/e2e/bazel-bzlmod-lock-file/rpms.json
@@ -5,14 +5,14 @@
             "name": "libvirt-libs",
             "sha256": "aac272a2ace134b5ef60a41e6624deb24331e79c76699ef6cef0dca22d94ac7e",
             "urls": [
-		"https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
+		"https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm"
             ]
 
         },
         {
             "sha256": "dba37bbe57903afe49b5666f1781eb50001baa81af4584b355db0b6a2afad9fa",
             "urls": [
-		"https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
+		"https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-devel-11.0.0-1.fc42.x86_64.rpm"
             ]
         }
     ]

--- a/e2e/bazel-bzlmod-lock-file/rpms.json
+++ b/e2e/bazel-bzlmod-lock-file/rpms.json
@@ -7,7 +7,6 @@
             "urls": [
 		"https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm"
             ]
-
         },
         {
             "sha256": "dba37bbe57903afe49b5666f1781eb50001baa81af4584b355db0b6a2afad9fa",

--- a/e2e/bazel-bzlmod-lock-file/rpms.json
+++ b/e2e/bazel-bzlmod-lock-file/rpms.json
@@ -3,18 +3,16 @@
     "rpms": [
         {
             "name": "libvirt-libs",
-            "sha256": "3a0a3d88c6cb90008fbe49fe05e7025056fb9fa3a887c4a78f79e63f8745c845",
+            "sha256": "aac272a2ace134b5ef60a41e6624deb24331e79c76699ef6cef0dca22d94ac7e",
             "urls": [
-                "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/l/libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
-                "https://storage.googleapis.com/builddeps/3a0a3d88c6cb90008fbe49fe05e7025056fb9fa3a887c4a78f79e63f8745c845"
+		"https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
             ]
 
         },
         {
-            "sha256": "2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6",
+            "sha256": "dba37bbe57903afe49b5666f1781eb50001baa81af4584b355db0b6a2afad9fa",
             "urls": [
-                "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/l/libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-                "https://storage.googleapis.com/builddeps/2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6"
+		"https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
             ]
         }
     ]

--- a/e2e/bazel-bzlmod-non-legacy-mode/BUILD.bazel
+++ b/e2e/bazel-bzlmod-non-legacy-mode/BUILD.bazel
@@ -8,8 +8,8 @@ bazeldnf(
 rpmtree(
     name = "something",
     rpms = [
-        "@bazeldnf_rpms//libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
-        "@bazeldnf_rpms//libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
+        "@bazeldnf_rpms//libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
+        "@bazeldnf_rpms//libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
     ],
 )
 
@@ -18,7 +18,7 @@ tar2files(
     files = {
         "/usr/lib64": [
             "libvirt.so.0",
-            "libvirt.so.0.6001.0",
+            "libvirt.so.0.11000.0",
         ],
     },
     tar = ":something",

--- a/e2e/bazel-bzlmod-non-legacy-mode/MODULE.bazel
+++ b/e2e/bazel-bzlmod-non-legacy-mode/MODULE.bazel
@@ -13,19 +13,17 @@ bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazeldnf = use_extension("@bazeldnf//bazeldnf:extensions.bzl", "bazeldnf")
 bazeldnf.config(legacy_mode = False)
 bazeldnf.rpm(
-    name = "libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
-    sha256 = "3a0a3d88c6cb90008fbe49fe05e7025056fb9fa3a887c4a78f79e63f8745c845",
+    name = "libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
+    sha256 = "aac272a2ace134b5ef60a41e6624deb24331e79c76699ef6cef0dca22d94ac7e",
     urls = [
-        "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/l/libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/3a0a3d88c6cb90008fbe49fe05e7025056fb9fa3a887c4a78f79e63f8745c845",
+        "https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
     ],
 )
 bazeldnf.rpm(
-    name = "libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-    sha256 = "2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6",
+    name = "libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
+    sha256 = "dba37bbe57903afe49b5666f1781eb50001baa81af4584b355db0b6a2afad9fa",
     urls = [
-        "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/l/libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6",
+        "https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
     ],
 )
 use_repo(bazeldnf, "bazeldnf_rpms")

--- a/e2e/bazel-bzlmod-toolchain-from-source/BUILD.bazel
+++ b/e2e/bazel-bzlmod-toolchain-from-source/BUILD.bazel
@@ -8,8 +8,8 @@ bazeldnf(
 rpmtree(
     name = "something",
     rpms = [
-        "@libvirt-libs-6.1.0-2.fc32.x86_64.rpm//rpm",
-        "@libvirt-devel-6.1.0-2.fc32.x86_64.rpm//rpm",
+        "@libvirt-libs-11.0.0-1.fc42.x86_64.rpm//rpm",
+        "@libvirt-devel-11.0.0-1.fc42.x86_64.rpm//rpm",
     ],
 )
 
@@ -18,7 +18,7 @@ tar2files(
     files = {
         "/usr/lib64": [
             "libvirt.so.0",
-            "libvirt.so.0.6001.0",
+            "libvirt.so.0.11000.0",
         ],
     },
     tar = ":something",

--- a/e2e/bazel-bzlmod-toolchain-from-source/MODULE.bazel
+++ b/e2e/bazel-bzlmod-toolchain-from-source/MODULE.bazel
@@ -30,23 +30,21 @@ use_repo(
 bazeldnf = use_extension("@bazeldnf//bazeldnf:extensions.bzl", "bazeldnf")
 bazeldnf.toolchain(disable = True)
 bazeldnf.rpm(
-    name = "libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
-    sha256 = "3a0a3d88c6cb90008fbe49fe05e7025056fb9fa3a887c4a78f79e63f8745c845",
+    name = "libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
+    sha256 = "aac272a2ace134b5ef60a41e6624deb24331e79c76699ef6cef0dca22d94ac7e",
     urls = [
-        "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/l/libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/3a0a3d88c6cb90008fbe49fe05e7025056fb9fa3a887c4a78f79e63f8745c845",
+        "https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
     ],
 )
 bazeldnf.rpm(
-    name = "libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-    sha256 = "2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6",
+    name = "libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
+    sha256 = "dba37bbe57903afe49b5666f1781eb50001baa81af4584b355db0b6a2afad9fa",
     urls = [
-        "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/l/libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6",
+        "https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
     ],
 )
 use_repo(
     bazeldnf,
-    "libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-    "libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
+    "libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
+    "libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
 )

--- a/e2e/bazel-bzlmod/BUILD.bazel
+++ b/e2e/bazel-bzlmod/BUILD.bazel
@@ -8,8 +8,8 @@ bazeldnf(
 rpmtree(
     name = "something",
     rpms = [
-        "@libvirt-libs-6.1.0-2.fc32.x86_64.rpm//rpm",
-        "@libvirt-devel-6.1.0-2.fc32.x86_64.rpm//rpm",
+        "@libvirt-libs-11.0.0-1.fc42.x86_64.rpm//rpm",
+        "@libvirt-devel-11.0.0-1.fc42.x86_64.rpm//rpm",
     ],
 )
 
@@ -18,7 +18,7 @@ tar2files(
     files = {
         "/usr/lib64": [
             "libvirt.so.0",
-            "libvirt.so.0.6001.0",
+            "libvirt.so.0.11000.0",
         ],
     },
     tar = ":something",

--- a/e2e/bazel-bzlmod/MODULE.bazel
+++ b/e2e/bazel-bzlmod/MODULE.bazel
@@ -27,6 +27,6 @@ bazeldnf.rpm(
 )
 use_repo(
     bazeldnf,
-    "libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-    "libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
+    "libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
+    "libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
 )

--- a/e2e/bazel-bzlmod/MODULE.bazel
+++ b/e2e/bazel-bzlmod/MODULE.bazel
@@ -12,19 +12,17 @@ bazel_dep(name = "rules_pkg", version = "1.0.1")
 
 bazeldnf = use_extension("@bazeldnf//bazeldnf:extensions.bzl", "bazeldnf")
 bazeldnf.rpm(
-    name = "libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
-    sha256 = "3a0a3d88c6cb90008fbe49fe05e7025056fb9fa3a887c4a78f79e63f8745c845",
+    name = "libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
+    sha256 = "aac272a2ace134b5ef60a41e6624deb24331e79c76699ef6cef0dca22d94ac7e",
     urls = [
-        "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/l/libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/3a0a3d88c6cb90008fbe49fe05e7025056fb9fa3a887c4a78f79e63f8745c845",
+        "https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
     ],
 )
 bazeldnf.rpm(
-    name = "libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-    sha256 = "2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6",
+    name = "libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
+    sha256 = "dba37bbe57903afe49b5666f1781eb50001baa81af4584b355db0b6a2afad9fa",
     urls = [
-        "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/l/libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6",
+        "https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
     ],
 )
 use_repo(

--- a/e2e/bazel-workspace/BUILD.bazel
+++ b/e2e/bazel-workspace/BUILD.bazel
@@ -8,8 +8,8 @@ bazeldnf(
 rpmtree(
     name = "something",
     rpms = [
-        "@libvirt-libs-6.1.0-2.fc32.x86_64.rpm//rpm",
-        "@libvirt-devel-6.1.0-2.fc32.x86_64.rpm//rpm",
+        "@libvirt-libs-11.0.0-1.fc42.x86_64.rpm//rpm",
+        "@libvirt-devel-11.0.0-1.fc42.x86_64.rpm//rpm",
     ],
 )
 
@@ -18,7 +18,7 @@ tar2files(
     files = {
         "/usr/lib64": [
             "libvirt.so.0",
-            "libvirt.so.0.6001.0",
+            "libvirt.so.0.11000.0",
         ],
     },
     tar = ":something",

--- a/pkg/rpm/BUILD.bazel
+++ b/pkg/rpm/BUILD.bazel
@@ -24,7 +24,10 @@ go_test(
         "rpm_test.go",
         "tar_test.go",
     ],
-    data = ["@libvirt-libs-11.0.0-1.fc42.x86_64.rpm//rpm"],
+    data = [
+        "@abseil-cpp-devel-20240722.1-1.fc42.x86_64.rpm//rpm",
+        "@libvirt-libs-11.0.0-1.fc42.x86_64.rpm//rpm",
+    ],
     embed = [":rpm"],
     deps = [
         "//pkg/api",

--- a/pkg/rpm/BUILD.bazel
+++ b/pkg/rpm/BUILD.bazel
@@ -24,7 +24,7 @@ go_test(
         "rpm_test.go",
         "tar_test.go",
     ],
-    data = ["@libvirt-libs-6.1.0-2.fc32.x86_64.rpm//rpm"],
+    data = ["@libvirt-libs-11.0.0-1.fc42.x86_64.rpm//rpm"],
     embed = [":rpm"],
     deps = [
         "//pkg/api",

--- a/pkg/rpm/tar.go
+++ b/pkg/rpm/tar.go
@@ -66,8 +66,13 @@ func PrefixFilter(prefix string, reader *tar.Reader, files []string) error {
 
 	fileMap := map[string]string{}
 	for _, file := range files {
-		fileMap[filepath.Base(file)] = file
+		prefixIdx := strings.Index(file, prefix)
+		if prefixIdx == -1 {
+			return fmt.Errorf("prefix %s is not found in %s", prefix, file)
+		}
+		fileMap[file[prefixIdx:]] = file
 	}
+
 	for {
 		entry, err := reader.Next()
 		if err == io.EOF {
@@ -82,13 +87,14 @@ func PrefixFilter(prefix string, reader *tar.Reader, files []string) error {
 		} else {
 			continue
 		}
-		basename := filepath.Base(name)
-		if _, exists := fileMap[basename]; !exists {
+
+		if _, exists := fileMap[name]; !exists {
 			continue
 		}
+
 		if entry.Typeflag == tar.TypeReg {
 			err := func() error {
-				writer, err := os.Create(fileMap[basename])
+				writer, err := os.Create(fileMap[name])
 				if err != nil {
 					return err
 				}
@@ -101,16 +107,16 @@ func PrefixFilter(prefix string, reader *tar.Reader, files []string) error {
 			if err != nil {
 				return err
 			}
-			delete(fileMap, basename)
+			delete(fileMap, name)
 		} else if entry.Typeflag == tar.TypeSymlink {
 			linkname := strings.TrimPrefix(entry.Linkname, ".")
-			err = os.Symlink(linkname, fileMap[basename])
+			err = os.Symlink(linkname, fileMap[name])
 			if err != nil {
 				return err
 			}
-			delete(fileMap, basename)
+			delete(fileMap, name)
 		} else {
-			return fmt.Errorf("can't extract %s, only symlinks and files can be specified", fileMap[basename])
+			return fmt.Errorf("can't extract %s, only symlinks and files can be specified", fileMap[name])
 		}
 	}
 

--- a/pkg/rpm/tar_test.go
+++ b/pkg/rpm/tar_test.go
@@ -23,7 +23,7 @@ func TestRPMToTar(t *testing.T) {
 	}{
 		{
 			name:    "should convert a RPM to tar and keep all entries",
-			rpm:     filepath.Join(os.Getenv("TEST_SRCDIR"), "libvirt-libs-6.1.0-2.fc32.x86_64.rpm/rpm/downloaded"),
+			rpm:     filepath.Join(os.Getenv("TEST_SRCDIR"), "libvirt-libs-11.0.0-1.fc42.x86_64.rpm/rpm/downloaded"),
 			wantErr: false,
 			expectedHeaders: []*tar.Header{
 				{Name: "./etc/libvirt/libvirt-admin.conf", Size: 450, Mode: 33188},
@@ -93,13 +93,13 @@ func TestTar2Files(t *testing.T) {
 	}{
 		{
 			name:    "should extract a symlink from a tar archive",
-			rpm:     filepath.Join(os.Getenv("TEST_SRCDIR"), "libvirt-libs-6.1.0-2.fc32.x86_64.rpm/rpm/downloaded"),
+			rpm:     filepath.Join(os.Getenv("TEST_SRCDIR"), "libvirt-libs-11.0.0-1.fc42.x86_64.rpm/rpm/downloaded"),
 			wantErr: false,
 			files:   []string{"/usr/lib64/libvirt.so.0"},
 			expected: []fileInfo{
 				{Name: "usr", Size: 96, Children: []fileInfo{
 					{Name: "lib64", Size: 96, Children: []fileInfo{
-						{Name: "libvirt.so.0", Size: 19},
+						{Name: "libvirt.so.0", Size: 20},
 					}},
 				}},
 			},

--- a/pkg/rpm/tar_test.go
+++ b/pkg/rpm/tar_test.go
@@ -107,7 +107,7 @@ func TestTar2Files(t *testing.T) {
 		},
 		{
 			name:    "should extract multiple files from a tar archive",
-			rpm:     filepath.Join(os.Getenv("TEST_SRCDIR"), "libvirt-libs-6.1.0-2.fc32.x86_64.rpm/rpm/downloaded"),
+			rpm:     filepath.Join(os.Getenv("TEST_SRCDIR"), "libvirt-libs-11.0.0-1.fc42.x86_64.rpm/rpm/downloaded"),
 			wantErr: false,
 			files: []string{
 				"/etc/libvirt/libvirt-admin.conf",
@@ -122,6 +122,30 @@ func TestTar2Files(t *testing.T) {
 				}},
 			},
 			prefix: "./etc/libvirt/",
+		},
+		{
+			name:    "should extract multiple files with the same name from a tar archive",
+			rpm:     filepath.Join(os.Getenv("TEST_SRCDIR"), "abseil-cpp-devel-20240722.1-1.fc42.x86_64.rpm/rpm/downloaded"),
+			wantErr: false,
+			files: []string{
+				"/usr/include/absl/log/globals.h",
+				"/usr/include/absl/log/internal/globals.h",
+			},
+			expected: []fileInfo{
+				{Name: "usr", Size: 96, Children: []fileInfo{
+					{Name: "include", Size: 96, Children: []fileInfo{
+						{Name: "absl", Size: 96, Children: []fileInfo{
+							{Name: "log", Size: 128, Children: []fileInfo{
+								{Name: "globals.h", Size: 8391},
+								{Name: "internal", Size: 96, Children: []fileInfo{
+									{Name: "globals.h", Size: 4030},
+								}},
+							}},
+						}},
+					}},
+				}},
+			},
+			prefix: "./usr/include/",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/rpm/tar_test.go
+++ b/pkg/rpm/tar_test.go
@@ -97,8 +97,8 @@ func TestTar2Files(t *testing.T) {
 			wantErr: false,
 			files:   []string{"/usr/lib64/libvirt.so.0"},
 			expected: []fileInfo{
-				{Name: "usr", Size: 96, Children: []fileInfo{
-					{Name: "lib64", Size: 96, Children: []fileInfo{
+				{Name: "usr", Children: []fileInfo{
+					{Name: "lib64", Children: []fileInfo{
 						{Name: "libvirt.so.0", Size: 20},
 					}},
 				}},
@@ -114,8 +114,8 @@ func TestTar2Files(t *testing.T) {
 				"/etc/libvirt/libvirt.conf",
 			},
 			expected: []fileInfo{
-				{Name: "etc", Size: 96, Children: []fileInfo{
-					{Name: "libvirt", Size: 128, Children: []fileInfo{
+				{Name: "etc", Children: []fileInfo{
+					{Name: "libvirt", Children: []fileInfo{
 						{Name: "libvirt-admin.conf", Size: 450},
 						{Name: "libvirt.conf", Size: 547},
 					}},
@@ -132,12 +132,12 @@ func TestTar2Files(t *testing.T) {
 				"/usr/include/absl/log/internal/globals.h",
 			},
 			expected: []fileInfo{
-				{Name: "usr", Size: 96, Children: []fileInfo{
-					{Name: "include", Size: 96, Children: []fileInfo{
-						{Name: "absl", Size: 96, Children: []fileInfo{
-							{Name: "log", Size: 128, Children: []fileInfo{
+				{Name: "usr", Children: []fileInfo{
+					{Name: "include", Children: []fileInfo{
+						{Name: "absl", Children: []fileInfo{
+							{Name: "log", Children: []fileInfo{
 								{Name: "globals.h", Size: 8391},
-								{Name: "internal", Size: 96, Children: []fileInfo{
+								{Name: "internal", Children: []fileInfo{
 									{Name: "globals.h", Size: 4030},
 								}},
 							}},
@@ -198,7 +198,6 @@ func collectFileInfo(dirName string) ([]fileInfo, error) {
 	for _, file := range fileInfos {
 		fileInfo := fileInfo{
 			Name: file.Name(),
-			Size: file.Size(),
 		}
 
 		if file.IsDir() {
@@ -207,6 +206,8 @@ func collectFileInfo(dirName string) ([]fileInfo, error) {
 				return r, err
 			}
 			fileInfo.Children = children
+		} else {
+			fileInfo.Size = file.Size()
 		}
 
 		r = append(r, fileInfo)

--- a/test_deps.bzl
+++ b/test_deps.bzl
@@ -18,3 +18,11 @@ def bazeldnf_test_dependencies():
             "https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
         ],
     )
+
+    rpm(
+        name = "abseil-cpp-devel-20240722.1-1.fc42.x86_64.rpm",
+        sha256 = "1393c28f5a3f3029769bbe3436b3eec58c7b11761c4ad6695c309b21474d9804",
+        urls = [
+            "https://kojipkgs.fedoraproject.org//packages/abseil-cpp/20240722.1/1.fc42/x86_64/abseil-cpp-devel-20240722.1-1.fc42.x86_64.rpm",
+        ],
+    )

--- a/test_deps.bzl
+++ b/test_deps.bzl
@@ -4,19 +4,17 @@ load("@bazeldnf//bazeldnf:defs.bzl", "rpm")
 
 def bazeldnf_test_dependencies():
     rpm(
-        name = "libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
-        sha256 = "3a0a3d88c6cb90008fbe49fe05e7025056fb9fa3a887c4a78f79e63f8745c845",
+        name = "libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
+        sha256 = "aac272a2ace134b5ef60a41e6624deb24331e79c76699ef6cef0dca22d94ac7e",
         urls = [
-            "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/l/libvirt-libs-6.1.0-2.fc32.x86_64.rpm",
-            "https://storage.googleapis.com/builddeps/3a0a3d88c6cb90008fbe49fe05e7025056fb9fa3a887c4a78f79e63f8745c845",
+            "https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
         ],
     )
 
     rpm(
-        name = "libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-        sha256 = "2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6",
+        name = "libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
+        sha256 = "dba37bbe57903afe49b5666f1781eb50001baa81af4584b355db0b6a2afad9fa",
         urls = [
-            "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/l/libvirt-devel-6.1.0-2.fc32.x86_64.rpm",
-            "https://storage.googleapis.com/builddeps/2ebb715341b57a74759aff415e0ff53df528c49abaa7ba5b794b4047461fa8d6",
+            "https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
         ],
     )


### PR DESCRIPTION
If two files have the same name but are found in different subdirectories then tar2files will fail.  An example of this is found in abseil-cpp where there are multiple headers with the same name, but sometimes in different subdirectories of `/usr/include`.

This change tweaks our tarfile handling so as to key our lookup map based on the path minus anything before the expected prefix (this will remove the `bazel-out/...` bits from the paths generated by the tar2files rule.  This provides enough context to avoid the name collisions but is still able to deal with the correct path lookup.