### PR TITLE
General improvements

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,6 +25,7 @@ go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(
     go_deps,
+    "com_github_adrg_xdg",
     "com_github_bazelbuild_buildtools",
     "com_github_crillab_gophersat",
     "com_github_onsi_gomega",

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -22,10 +22,11 @@ func NewFetchCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return repo.NewRemoteRepoFetcher(repos.Repositories, ".bazeldnf").Fetch()
+			return repo.NewRemoteRepoFetcher(repos.Repositories).Fetch()
 		},
 	}
 
 	fetchCmd.Flags().StringArrayVarP(&fetchopts.repofiles, "repofile", "r", []string{"repo.yaml"}, "repository information file. Can be specified multiple times")
+	repo.AddCacheHelperFlags(fetchCmd)
 	return fetchCmd
 }

--- a/cmd/reduce.go
+++ b/cmd/reduce.go
@@ -42,7 +42,15 @@ which allow reducing huge rpm repos to a smaller problem set for debugging, remo
 					return err
 				}
 			}
-			_, involved, err := reducer.Resolve(repos, reduceopts.in, reduceopts.baseSystem, reduceopts.arch, required)
+
+			repo := reducer.NewRepoReducer(repos, reduceopts.in, reduceopts.baseSystem, reduceopts.arch, repo.NewCacheHelper())
+			logrus.Info("Loading packages.")
+			if err := repo.Load(); err != nil {
+				return err
+			}
+			logrus.Info("Reduction of involved packages.")
+			_, involved, err := repo.Resolve(required)
+
 			if err != nil {
 				return err
 			}
@@ -74,5 +82,8 @@ which allow reducing huge rpm repos to a smaller problem set for debugging, remo
 	reduceCmd.Flags().MarkDeprecated("fedora-base-system", "use --basesystem instead")
 	reduceCmd.Flags().MarkShorthandDeprecated("fedora-base-system", "use --basesystem instead")
 	reduceCmd.Flags().MarkShorthandDeprecated("nobest", "use --nobest instead")
+
+	repo.AddCacheHelperFlags(reduceCmd)
+
 	return reduceCmd
 }

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -39,7 +39,14 @@ func NewResolveCmd() *cobra.Command {
 					return err
 				}
 			}
-			matched, involved, err := reducer.Resolve(repos, resolveopts.in, resolveopts.baseSystem, resolveopts.arch, required)
+			repo := reducer.NewRepoReducer(repos, resolveopts.in, resolveopts.baseSystem, resolveopts.arch, repo.NewCacheHelper())
+			logrus.Info("Loading packages.")
+			if err := repo.Load(); err != nil {
+				return err
+			}
+			logrus.Info("Initial reduction of involved packages.")
+			matched, involved, err := repo.Resolve(required)
+
 			if err != nil {
 				return err
 			}
@@ -77,5 +84,7 @@ func NewResolveCmd() *cobra.Command {
 	resolveCmd.Flags().MarkDeprecated("fedora-base-system", "use --basesystem instead")
 	resolveCmd.Flags().MarkShorthandDeprecated("fedora-base-system", "use --basesystem instead")
 	resolveCmd.Flags().MarkShorthandDeprecated("nobest", "use --nobest instead")
+	repo.AddCacheHelperFlags(resolveCmd)
+
 	return resolveCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +17,15 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	if logLevel, hasIt := os.LookupEnv("BAZELDNF_LOG_LEVEL"); hasIt {
+		level, err := logrus.ParseLevel(logLevel)
+		if err != nil {
+			fmt.Println("Unable to parse log level from environment variable BAZELDNF_LOG_LEVEL")
+			os.Exit(1)
+		}
+		logrus.SetLevel(level)
+	}
+
 	rootCmd.AddCommand(NewXATTRCmd())
 	rootCmd.AddCommand(NewSandboxCmd())
 	rootCmd.AddCommand(NewFetchCmd())

--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -41,7 +41,14 @@ func NewRpmTreeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			matched, involved, err := reducer.Resolve(repos, nil, rpmtreeopts.baseSystem, rpmtreeopts.arch, required)
+			repoReducer := reducer.NewRepoReducer(repos, nil, rpmtreeopts.baseSystem, rpmtreeopts.arch, repo.NewCacheHelper())
+			logrus.Info("Loading packages.")
+			if err := repoReducer.Load(); err != nil {
+				return err
+			}
+			logrus.Info("Initial reduction of involved packages.")
+			matched, involved, err := repoReducer.Resolve(required)
+
 			if err != nil {
 				return err
 			}
@@ -137,5 +144,7 @@ func NewRpmTreeCmd() *cobra.Command {
 	rpmtreeCmd.Flags().MarkDeprecated("fedora-base-system", "use --basesystem instead")
 	rpmtreeCmd.Flags().MarkShorthandDeprecated("fedora-base-system", "use --basesystem instead")
 	rpmtreeCmd.Flags().MarkShorthandDeprecated("nobest", "use --nobest instead")
+	repo.AddCacheHelperFlags(rpmtreeCmd)
+
 	return rpmtreeCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	github.com/adrg/xdg v0.5.3
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
+github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/bazelbuild/buildtools v0.0.0-20240823132350-3488089d3661 h1:acJJwAuD2t36RHnvxf3oh9lhg5LISUYXunx+om2ONZw=
 github.com/bazelbuild/buildtools v0.0.0-20240823132350-3488089d3661/go.mod h1:yBQGNvRAGhcBTxe4MHiW3Ul7DwoBim4XsKUaXnW1LWc=
 github.com/bazelbuild/buildtools v0.0.0-20250110114635-13fa61383b99 h1:3Wvirn7fGxAk5XMO5OV9goElw2ZKya/erxxHChPSPQM=
@@ -43,6 +45,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/reducer/reducer.go
+++ b/pkg/reducer/reducer.go
@@ -121,7 +121,7 @@ func (r *RepoReducer) requires(p *api.Package) (wants []*api.Package) {
 	return wants
 }
 
-func NewRepoReducer(repos *bazeldnf.Repositories, repoFiles []string, baseSystem string, arch string, cachDir string) *RepoReducer {
+func NewRepoReducer(repos *bazeldnf.Repositories, repoFiles []string, baseSystem string, arch string, cacheHelper *repo.CacheHelper) *RepoReducer {
 	return &RepoReducer{
 		packageInfo:      nil,
 		implicitRequires: []string{baseSystem},
@@ -130,17 +130,7 @@ func NewRepoReducer(repos *bazeldnf.Repositories, repoFiles []string, baseSystem
 			architectures: []string{"noarch", arch},
 			arch:          arch,
 			repos:         repos,
-			cacheHelper:   &repo.CacheHelper{CacheDir: cachDir},
+			cacheHelper:   cacheHelper,
 		},
 	}
-}
-
-func Resolve(repos *bazeldnf.Repositories, repoFiles []string, baseSystem, arch string, packages []string) (matched []string, involved []*api.Package, err error) {
-	repoReducer := NewRepoReducer(repos, repoFiles, baseSystem, arch, ".bazeldnf")
-	logrus.Info("Loading packages.")
-	if err := repoReducer.Load(); err != nil {
-		return nil, nil, err
-	}
-	logrus.Info("Initial reduction of involved packages.")
-	return repoReducer.Resolve(packages)
 }

--- a/pkg/repo/BUILD.bazel
+++ b/pkg/repo/BUILD.bazel
@@ -13,7 +13,9 @@ go_library(
         "//pkg/api",
         "//pkg/api/bazeldnf",
         "//pkg/rpm",
+        "@com_github_adrg_xdg//:xdg",
         "@com_github_sirupsen_logrus//:logrus",
+        "@com_github_spf13_cobra//:cobra",
         "@io_k8s_sigs_yaml//:yaml",
     ],
 )

--- a/pkg/repo/cache.go
+++ b/pkg/repo/cache.go
@@ -242,7 +242,8 @@ func (r *CacheHelper) CurrentFilelistsForPackages(repo *bazeldnf.Repository, arc
 
 func (r *CacheHelper) CurrentPrimaries(repos *bazeldnf.Repositories, arch string) (primaries []*api.Repository, err error) {
 	for i, repo := range repos.Repositories {
-		if repo.Arch != arch {
+		if repo.Arch != arch && repo.Arch != "noarch" {
+			logrus.Infof("Ignoring primary for %s - %s", repo.Name, repo.Arch)
 			continue
 		}
 		primary, err := r.CurrentPrimary(&repos.Repositories[i])

--- a/pkg/repo/cache.go
+++ b/pkg/repo/cache.go
@@ -37,8 +37,11 @@ func NewCacheHelper(cacheDir ...string) *CacheHelper {
 
 	logrus.Infof("Using cache directory %s", cacheDir[0])
 
+	dir := strings.ReplaceAll(cacheDir[0], "~", "${HOME}")
+	dir = os.ExpandEnv(dir)
+
 	return &CacheHelper{
-		cacheDir: cacheDir[0],
+		cacheDir: dir,
 	}
 }
 

--- a/pkg/repo/fetch.go
+++ b/pkg/repo/fetch.go
@@ -63,11 +63,11 @@ func (r *RepoFetcherImpl) Fetch() (err error) {
 	return nil
 }
 
-func NewRemoteRepoFetcher(repos []bazeldnf.Repository, cacheDir string) RepoFetcher {
+func NewRemoteRepoFetcher(repos []bazeldnf.Repository) RepoFetcher {
 	return &RepoFetcherImpl{
 		Repos:       repos,
 		Getter:      &getterImpl{},
-		CacheHelper: &CacheHelper{CacheDir: cacheDir},
+		CacheHelper: NewCacheHelper(),
 	}
 }
 

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -13,7 +13,7 @@ func Test(t *testing.T) {
 		fmt.Println(err)
 		return
 	}
-	helper := CacheHelper{CacheDir: ".bazeldnf"}
+	helper := NewCacheHelper(".bazeldnf")
 	a, b, err := helper.CurrentFilelistsForPackages(&repos.Repositories[0], []string{"myarch"}, []*api.Package{
 		{Name: "blub", Arch: "myarch", Version: api.Version{Epoch: "1"}},
 		{Name: "blub", Arch: "myarch", Version: api.Version{Epoch: "3"}},


### PR DESCRIPTION
*NOTE*: This is a replacement for #89, based on my company fork so I can push force and fix commits.


Changes:
* allow to configure the log level (logrus) through an environmental variable, so we don't need to rebuild the binary each time.
* allow to configure the rpm database cache path, this cache by default is stored relatively to the path where the binary gets called, but this means it can't be shared across multiple workspaces using bazeldnf and the same repos, and also that when multiple OSes are being used conflicts can arise (for instance when mixing centos7 and centos stream 9 while doing a migration). By making the path configurable and relative to XDG paths we can get some isolation. This cache is not used by bazel operations, but by bazeldnf binary when resolving dependency trees.
* honor noarch repositories to avoid ending up with non fullfilled dependencies