### PR TITLE
Allow us to ignore missing packages when resolving

### DIFF
--- a/cmd/reduce.go
+++ b/cmd/reduce.go
@@ -69,7 +69,7 @@ which allow reducing huge rpm repos to a smaller problem set for debugging, remo
 	reduceCmd.Flags().StringVar(&reduceopts.baseSystem, "basesystem", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")
 	reduceCmd.Flags().StringVarP(&reduceopts.arch, "arch", "a", "x86_64", "target architecture")
 	reduceCmd.Flags().BoolVarP(&reduceopts.nobest, "nobest", "n", false, "allow picking versions which are not the newest")
-	reduceCmd.Flags().BoolVarP(&reduceopts.ignoreMissing, "ignore-missing", "i", false, "ignore missing packages")
+	reduceCmd.Flags().BoolVar(&reduceopts.ignoreMissing, "ignore-missing", false, "ignore missing packages")
 	reduceCmd.Flags().StringArrayVarP(&reduceopts.repofiles, "repofile", "r", []string{"repo.yaml"}, "repository information file. Can be specified multiple times. Will be used by default if no explicit inputs are provided.")
 	// deprecated options
 	reduceCmd.Flags().StringVarP(&reduceopts.baseSystem, "fedora-base-system", "f", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")

--- a/cmd/reduce.go
+++ b/cmd/reduce.go
@@ -14,12 +14,13 @@ import (
 )
 
 type reduceOpts struct {
-	in         []string
-	repofiles  []string
-	out        string
-	nobest     bool
-	arch       string
-	baseSystem string
+	in            []string
+	repofiles     []string
+	out           string
+	nobest        bool
+	ignoreMissing bool
+	arch          string
+	baseSystem    string
 }
 
 var reduceopts = reduceOpts{}
@@ -42,7 +43,7 @@ which allow reducing huge rpm repos to a smaller problem set for debugging, remo
 					return err
 				}
 			}
-			_, involved, err := reducer.Resolve(repos, reduceopts.in, reduceopts.baseSystem, reduceopts.arch, required)
+			_, involved, err := reducer.Resolve(repos, reduceopts.in, reduceopts.baseSystem, reduceopts.arch, required, reduceopts.ignoreMissing)
 			if err != nil {
 				return err
 			}
@@ -68,6 +69,7 @@ which allow reducing huge rpm repos to a smaller problem set for debugging, remo
 	reduceCmd.Flags().StringVar(&reduceopts.baseSystem, "basesystem", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")
 	reduceCmd.Flags().StringVarP(&reduceopts.arch, "arch", "a", "x86_64", "target architecture")
 	reduceCmd.Flags().BoolVarP(&reduceopts.nobest, "nobest", "n", false, "allow picking versions which are not the newest")
+	reduceCmd.Flags().BoolVarP(&reduceopts.ignoreMissing, "ignore-missing", "i", false, "ignore missing packages")
 	reduceCmd.Flags().StringArrayVarP(&reduceopts.repofiles, "repofile", "r", []string{"repo.yaml"}, "repository information file. Can be specified multiple times. Will be used by default if no explicit inputs are provided.")
 	// deprecated options
 	reduceCmd.Flags().StringVarP(&reduceopts.baseSystem, "fedora-base-system", "f", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")

--- a/cmd/resolve_helper.go
+++ b/cmd/resolve_helper.go
@@ -52,7 +52,7 @@ func addResolveHelperFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&resolvehelperopts.baseSystem, "basesystem", "fedora-release-container", "base system to use (e.g. fedora-release-server, centos-stream-release, ...)")
 	cmd.Flags().StringVarP(&resolvehelperopts.arch, "arch", "a", "x86_64", "target architecture")
 	cmd.Flags().BoolVarP(&resolvehelperopts.nobest, "nobest", "n", false, "allow picking versions which are not the newest")
-	cmd.Flags().BoolVarP(&resolvehelperopts.ignoreMissing, "ignore-missing", "i", false, "ignore missing packages")
+	cmd.Flags().BoolVar(&resolvehelperopts.ignoreMissing, "ignore-missing", false, "ignore missing packages")
 	cmd.Flags().StringArrayVar(&resolvehelperopts.forceIgnoreRegex, "force-ignore-with-dependencies", []string{}, "Packages matching these regex patterns will not be installed. Allows force-removing unwanted dependencies. Be careful, this can lead to hidden missing dependencies.")
 	cmd.Flags().StringArrayVar(&resolvehelperopts.onlyAllowRegex, "only-allow", []string{}, "Packages matching these regex patterns may be installed. Allows scoping dependencies. Be careful, this can lead to hidden missing dependencies.")
 	// deprecated options

--- a/pkg/reducer/reducer.go
+++ b/pkg/reducer/reducer.go
@@ -25,7 +25,7 @@ func (r *RepoReducer) Load() error {
 	return nil
 }
 
-func (r *RepoReducer) Resolve(packages []string) (matched []string, involved []*api.Package, err error) {
+func (r *RepoReducer) Resolve(packages []string, ignoreMissing bool) (matched []string, involved []*api.Package, err error) {
 	packages = append(packages, r.implicitRequires...)
 	discovered := map[string]*api.Package{}
 	pinned := map[string]*api.Package{}
@@ -46,7 +46,7 @@ func (r *RepoReducer) Resolve(packages []string) (matched []string, involved []*
 				}
 			}
 		}
-		if !found {
+		if !found && !ignoreMissing {
 			return nil, nil, fmt.Errorf("Package %s does not exist", req)
 		}
 
@@ -142,12 +142,12 @@ func NewRepoReducer(repos *bazeldnf.Repositories, repoFiles []string, baseSystem
 	}
 }
 
-func Resolve(repos *bazeldnf.Repositories, repoFiles []string, baseSystem, arch string, packages []string) (matched []string, involved []*api.Package, err error) {
+func Resolve(repos *bazeldnf.Repositories, repoFiles []string, baseSystem, arch string, packages []string, ignoreMissing bool) (matched []string, involved []*api.Package, err error) {
 	repoReducer := NewRepoReducer(repos, repoFiles, baseSystem, arch, repo.NewCacheHelper())
 	logrus.Info("Loading packages.")
 	if err := repoReducer.Load(); err != nil {
 		return nil, nil, err
 	}
 	logrus.Info("Initial reduction of involved packages.")
-	return repoReducer.Resolve(packages)
+	return repoReducer.Resolve(packages, ignoreMissing)
 }


### PR DESCRIPTION
In some cases we might have packages that are missing and we wish to ignore them in the grand scheme of things.  This knob allows us to ignore packages (specified or dependencies) that are missing and to otherwise just continue about our business.