### PR TITLE
Add SHA512 and SHA1 support for downloaded files

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -115,11 +115,25 @@ type Data struct {
 	HeaderSize string `xml:"header-size"`
 }
 
+func (d *Data) SHA512() (string, error) {
+	if d.Checksum.Type == "sha512" {
+		return d.Checksum.Text, nil
+	}
+	return "", fmt.Errorf("no sha512 found")
+}
+
 func (d *Data) SHA256() (string, error) {
 	if d.Checksum.Type == "sha256" {
 		return d.Checksum.Text, nil
 	}
 	return "", fmt.Errorf("no sha256 found")
+}
+
+func (d *Data) SHA() (string, error) {
+	if d.Checksum.Type == "sha" {
+		return d.Checksum.Text, nil
+	}
+	return "", fmt.Errorf("no sha found")
 }
 
 type Repomd struct {


### PR DESCRIPTION
Currently if we have a SHA1 or SHA512 sum we'll fail - the assumption is that the checksums are always SHA256.  This change enables us to work in priority order to (SHA512, SHA256, SHA1) to find a usable checksum and use that instead.

This fixes #29 