### PR TITLE
Enable bazel 8 support

### DIFF
--- a/.aspect/bazelrc/bazel6.bazelrc
+++ b/.aspect/bazelrc/bazel6.bazelrc
@@ -20,8 +20,35 @@ build --noexperimental_action_cache_store_output_metadata
 # when local debugging.
 # Docs: https://github.com/bazelbuild/bazel/blob/1af61b21df99edc2fc66939cdf14449c2661f873/src/main/java/com/google/devtools/build/lib/pkgcache/PackageOptions.java#L185
 # NB: This flag is in bazel6.bazelrc as when used in Bazel 7 is has been observed to break
-# "build without the bytes" --remote_download_outputs=toplevel. See https://github.com/aspect-build/bazel-lib/pull/711
+# "build without the bytes" --remote_download_outputs=toplevel. See https://github.com/bazel-contrib/bazel-lib/pull/711
 # for more info.
 build --noexperimental_check_output_files
 fetch --noexperimental_check_output_files
 query --noexperimental_check_output_files
+
+# Don't apply `--noremote_upload_local_results` and `--noremote_accept_cached` to the disk cache.
+# If you have both `--noremote_upload_local_results` and `--disk_cache`, then this fixes a bug where
+# Bazel doesn't write to the local disk cache as it treats as a remote cache.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_remote_results_ignore_disk
+# NB: This flag is in bazel6.bazelrc because it became a no-op in Bazel 7 and has been removed
+# in Bazel 8.
+build --incompatible_remote_results_ignore_disk
+
+# Propagate tags from a target declaration to the actions' execution requirements.
+# Ensures that tags applied in your BUILD file, like `tags=["no-remote"]`
+# get propagated to actions created by the rule.
+# Without this option, you rely on rules authors to manually check the tags you passed
+# and apply relevant ones to the actions they create.
+# See https://github.com/bazelbuild/bazel/issues/8830 for details.
+# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_allow_tags_propagation
+build --experimental_allow_tags_propagation
+fetch --experimental_allow_tags_propagation
+query --experimental_allow_tags_propagation
+
+# Do not build runfiles symlink forests for external repositories under
+# `.runfiles/wsname/external/repo` (in addition to `.runfiles/repo`). This reduces runfiles &
+# sandbox creation times & prevents accidentally depending on this feature which may flip to off by
+# default in the future. Note, some rules may fail under this flag, please file issues with the rule
+# author.
+# Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
+build --nolegacy_external_runfiles

--- a/.aspect/bazelrc/bazel7.bazelrc
+++ b/.aspect/bazelrc/bazel7.bazelrc
@@ -13,3 +13,11 @@ common --check_direct_dependencies=off
 # build.
 # Docs: https://bazel.build/reference/command-line-reference#flag--reuse_sandbox_directories
 build --reuse_sandbox_directories
+
+# Do not build runfiles symlink forests for external repositories under
+# `.runfiles/wsname/external/repo` (in addition to `.runfiles/repo`). This reduces runfiles &
+# sandbox creation times & prevents accidentally depending on this feature which may flip to off by
+# default in the future. Note, some rules may fail under this flag, please file issues with the rule
+# author.
+# Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
+build --nolegacy_external_runfiles

--- a/.aspect/bazelrc/correctness.bazelrc
+++ b/.aspect/bazelrc/correctness.bazelrc
@@ -24,7 +24,7 @@ test --test_verbose_timeout_warnings
 # Allow the Bazel server to check directory sources for changes. Ensures that the Bazel server
 # notices when a directory changes, if you have a directory listed in the srcs of some target.
 # Recommended when using
-# [copy_directory](https://github.com/aspect-build/bazel-lib/blob/main/docs/copy_directory.md) and
+# [copy_directory](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/copy_directory.md) and
 # [rules_js](https://github.com/aspect-build/rules_js) since npm package are source directories
 # inputs to copy_directory actions.
 # Docs: https://bazel.build/reference/command-line-reference#flag--host_jvm_args
@@ -41,17 +41,6 @@ test --incompatible_exclusive_test_sandboxed
 # client, but note that doing so can prevent cross-user caching if a shared cache is used.
 # Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_strict_action_env
 build --incompatible_strict_action_env
-
-# Propagate tags from a target declaration to the actions' execution requirements.
-# Ensures that tags applied in your BUILD file, like `tags=["no-remote"]`
-# get propagated to actions created by the rule.
-# Without this option, you rely on rules authors to manually check the tags you passed
-# and apply relevant ones to the actions they create.
-# See https://github.com/bazelbuild/bazel/issues/8830 for details.
-# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_allow_tags_propagation
-build --experimental_allow_tags_propagation
-fetch --experimental_allow_tags_propagation
-query --experimental_allow_tags_propagation
 
 # Do not automatically create `__init__.py` files in the runfiles of Python targets. Fixes the wrong
 # default that comes from Google's internal monorepo by using `__init__.py` to delimit a Python

--- a/.aspect/bazelrc/java.bazelrc
+++ b/.aspect/bazelrc/java.bazelrc
@@ -1,0 +1,27 @@
+# Aspect recommended Bazel flags when using rules_java and rules_jvm_external
+
+# Pin java versions to desired language level
+# See https://bazel.build/docs/bazel-and-java#java-versions
+# and https://en.wikipedia.org/wiki/Java_version_history
+
+# What version of Java are the source files in this repo?
+# See https://bazel.build/docs/user-manual#java-language-version
+common --java_language_version=17
+
+# The Java language version used to build tools that are executed during a build
+# See https://bazel.build/docs/user-manual#tool-java-language-version
+common --tool_java_language_version=17
+
+# The version of JVM to use to execute the code and run the tests.
+# NB: The default value is local_jdk which is non-hermetic.
+# See https://bazel.build/docs/user-manual#java-runtime-version
+common --java_runtime_version=remotejdk_17
+
+# The version of JVM used to execute tools that are needed during a build.
+# See https://bazel.build/docs/user-manual#tool-java-runtime-version
+common --tool_java_runtime_version=remotejdk_17
+
+# Repository rules, such as rules_jvm_external: put Bazel's JDK on the path.
+# Avoids non-hermeticity from dependency on a JAVA_HOME pointing at a system JDK
+# see https://github.com/bazelbuild/rules_jvm_external/issues/445
+common --repo_env=JAVA_HOME=../bazel_tools/jdk

--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -1,9 +1,3 @@
-# Don't apply `--noremote_upload_local_results` and `--noremote_accept_cached` to the disk cache.
-# If you have both `--noremote_upload_local_results` and `--disk_cache`, then this fixes a bug where
-# Bazel doesn't write to the local disk cache as it treats as a remote cache.
-# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_remote_results_ignore_disk
-build --incompatible_remote_results_ignore_disk
-
 # Directories used by sandboxed non-worker execution may be reused to avoid unnecessary setup costs.
 # Save time on Sandbox creation and deletion when many of the same kind of action run during the
 # build.

--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -5,10 +5,15 @@
 # Docs: https://bazel.build/reference/command-line-reference#flag--reuse_sandbox_directories
 build --experimental_reuse_sandbox_directories
 
-# Do not build runfiles symlink forests for external repositories under
-# `.runfiles/wsname/external/repo` (in addition to `.runfiles/repo`). This reduces runfiles &
-# sandbox creation times & prevents accidentally depending on this feature which may flip to off by
-# default in the future. Note, some rules may fail under this flag, please file issues with the rule
-# author.
-# Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
-build --nolegacy_external_runfiles
+# Avoid creating a runfiles tree for binaries or tests until it is needed.
+# Docs: https://bazel.build/reference/command-line-reference#flag--build_runfile_links
+# See https://github.com/bazelbuild/bazel/issues/6627
+#
+# This may break local workflows that `build` a binary target, then run the resulting program
+# outside of `bazel run`. In those cases, the script will need to call
+# `bazel build --build_runfile_links //my/binary:target` and then execute the resulting program.
+build --nobuild_runfile_links
+
+# Needed prior to Bazel 8; see
+# https://github.com/bazelbuild/bazel/issues/20577
+coverage --build_runfile_links

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -92,11 +92,7 @@ jobs:
   e2e-bzlmod-build-toolchain-matrix:
     strategy:
       matrix:
-        config:
-          - version: 7.x
-            flags: --incompatible_enable_proto_toolchain_resolution
-          - version: 8.x
-            flags: --incompatible_enable_proto_toolchain_resolution
+        version: [7.x, 8.x]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -66,7 +66,7 @@ jobs:
   e2e-bzlmod-matrix:
     strategy:
       matrix:
-        version: [7.x]
+        version: [7.x, 8.x]
         path:
           - bazel-bzlmod
           - bazel-bzlmod-non-legacy-mode
@@ -94,6 +94,8 @@ jobs:
       matrix:
         config:
           - version: 7.x
+            flags: --incompatible_enable_proto_toolchain_resolution
+          - version: 8.x
             flags: --incompatible_enable_proto_toolchain_resolution
 
     runs-on: ubuntu-latest

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -51,14 +51,17 @@ bazel_dep(name = "rules_go", version = "0.52.0")
 bazel_dep(name = "protobuf", version = "27.3", dev_dependency = True)
 bazel_dep(name = "toolchains_protoc", version = "0.3.7", dev_dependency = True)
 
-protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
+protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc", dev_dependency = True)
 protoc.toolchain(
     google_protobuf = "com_google_protobuf",
     version = "v27.3",
 )
 use_repo(protoc, "com_google_protobuf", "toolchains_protoc_hub")
 
-register_toolchains("@toolchains_protoc_hub//:all")
+register_toolchains(
+    "@toolchains_protoc_hub//:all",
+    dev_dependency = True,
+)
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,16 @@ bazel_dep(name = "gazelle", version = "0.42.0")
 bazel_dep(name = "rules_go", version = "0.52.0")
 
 bazel_dep(name = "protobuf", version = "27.3", dev_dependency = True)
-bazel_dep(name = "toolchains_protoc", version = "0.3.2", dev_dependency = True)
+bazel_dep(name = "toolchains_protoc", version = "0.3.7", dev_dependency = True)
+
+protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
+protoc.toolchain(
+    google_protobuf = "com_google_protobuf",
+    version = "v27.3",
+)
+use_repo(protoc, "com_google_protobuf", "toolchains_protoc_hub")
+
+register_toolchains("@toolchains_protoc_hub//:all")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
@@ -73,7 +82,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.8.1", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
 bazel_dep(name = "rules_pkg", version = "1.0.1", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
-bazel_dep(name = "rules_proto", version = "6.0.0", dev_dependency = True)
+bazel_dep(name = "rules_proto", version = "7.1.0", dev_dependency = True)
 bazel_dep(name = "rules_java", version = "7.9.0", dev_dependency = True)
 
 http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -81,7 +81,7 @@ use_repo(
 
 # deps only needed for the repo internals
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.7.1", dev_dependency = True)
-bazel_dep(name = "aspect_bazel_lib", version = "2.8.1", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "2.13.0", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
 bazel_dep(name = "rules_pkg", version = "1.0.1", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,11 +52,7 @@ bazel_dep(name = "protobuf", version = "27.3", dev_dependency = True)
 bazel_dep(name = "toolchains_protoc", version = "0.3.7", dev_dependency = True)
 
 protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc", dev_dependency = True)
-protoc.toolchain(
-    google_protobuf = "com_google_protobuf",
-    version = "v27.3",
-)
-use_repo(protoc, "com_google_protobuf", "toolchains_protoc_hub")
+use_repo(protoc, "toolchains_protoc_hub")
 
 register_toolchains(
     "@toolchains_protoc_hub//:all",

--- a/e2e/bazel-bzlmod-lock-file/.bazelrc
+++ b/e2e/bazel-bzlmod-lock-file/.bazelrc
@@ -1,6 +1,5 @@
 # Import Aspect bazelrc presets
 try-import %workspace%/../../.aspect/bazelrc/bazel7.bazelrc
-import %workspace%/../../.aspect/bazelrc/bazel6.bazelrc
 import %workspace%/../../.aspect/bazelrc/convenience.bazelrc
 import %workspace%/../../.aspect/bazelrc/correctness.bazelrc
 import %workspace%/../../.aspect/bazelrc/debug.bazelrc

--- a/e2e/bazel-bzlmod-non-legacy-mode/.bazelrc
+++ b/e2e/bazel-bzlmod-non-legacy-mode/.bazelrc
@@ -1,6 +1,5 @@
 # Import Aspect bazelrc presets
 try-import %workspace%/../../.aspect/bazelrc/bazel7.bazelrc
-import %workspace%/../../.aspect/bazelrc/bazel6.bazelrc
 import %workspace%/../../.aspect/bazelrc/convenience.bazelrc
 import %workspace%/../../.aspect/bazelrc/correctness.bazelrc
 import %workspace%/../../.aspect/bazelrc/debug.bazelrc

--- a/e2e/bazel-bzlmod-toolchain-from-source/.bazelrc
+++ b/e2e/bazel-bzlmod-toolchain-from-source/.bazelrc
@@ -1,6 +1,5 @@
 # Import Aspect bazelrc presets
 try-import %workspace%/../../.aspect/bazelrc/bazel7.bazelrc
-import %workspace%/../../.aspect/bazelrc/bazel6.bazelrc
 import %workspace%/../../.aspect/bazelrc/convenience.bazelrc
 import %workspace%/../../.aspect/bazelrc/correctness.bazelrc
 import %workspace%/../../.aspect/bazelrc/debug.bazelrc

--- a/e2e/bazel-bzlmod-toolchain-from-source/.bazelrc
+++ b/e2e/bazel-bzlmod-toolchain-from-source/.bazelrc
@@ -8,6 +8,7 @@ import %workspace%/../../.aspect/bazelrc/performance.bazelrc
 # Specific project flags go here if we have some
 common --enable_bzlmod
 common --extra_toolchains=@bazeldnf//cmd:bazeldnf-host-toolchain
+common --incompatible_enable_proto_toolchain_resolution
 
 # Load any settings & overrides specific to the current user from `.bazelrc.user`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This

--- a/e2e/bazel-bzlmod-toolchain-from-source/MODULE.bazel
+++ b/e2e/bazel-bzlmod-toolchain-from-source/MODULE.bazel
@@ -11,7 +11,19 @@ local_path_override(
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_go", version = "0.49.0", repo_name = "rules_go")
 bazel_dep(name = "gazelle", version = "0.37.0")
-bazel_dep(name = "toolchains_protoc", version = "0.3.2")
+bazel_dep(name = "toolchains_protoc", version = "0.3.7")
+
+protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
+protoc.toolchain(
+    google_protobuf = "com_google_protobuf",
+    version = "v27.3",
+)
+use_repo(protoc, "com_google_protobuf", "toolchains_protoc_hub")
+
+register_toolchains(
+    "@toolchains_protoc_hub//:all",
+    dev_dependency = True,
+)
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "@bazeldnf//:go.mod")

--- a/e2e/bazel-bzlmod/.bazelrc
+++ b/e2e/bazel-bzlmod/.bazelrc
@@ -1,6 +1,5 @@
 # Import Aspect bazelrc presets
 try-import %workspace%/../../.aspect/bazelrc/bazel7.bazelrc
-import %workspace%/../../.aspect/bazelrc/bazel6.bazelrc
 import %workspace%/../../.aspect/bazelrc/convenience.bazelrc
 import %workspace%/../../.aspect/bazelrc/correctness.bazelrc
 import %workspace%/../../.aspect/bazelrc/debug.bazelrc


### PR DESCRIPTION
This change enables bazel 8 support and drops bazel 6 support for the bzlmod e2e tests.