### PR TITLE
Add lockfile command to bazeldnf

### DIFF
--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -1,14 +1,16 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//bazeldnf:toolchain.bzl", "bazeldnf_toolchain")
 
 go_library(
     name = "cmd_lib",
     srcs = [
         "bazeldnf.go",
+        "config_helper.go",
         "fetch.go",
         "filter.go",
         "init.go",
         "ldd.go",
+        "lockfile.go",
         "prune.go",
         "reduce.go",
         "resolve.go",
@@ -40,6 +42,7 @@ go_library(
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_spf13_cobra//:cobra",
         "@org_golang_x_crypto//openpgp",
+        "@org_golang_x_exp//maps",
     ],
 )
 
@@ -59,4 +62,15 @@ toolchain(
     name = "bazeldnf-host-toolchain",
     toolchain = ":host-toolchain",
     toolchain_type = "//bazeldnf:toolchain_type",
+)
+
+go_test(
+    name = "cmd_test",
+    srcs = ["config_helper_test.go"],
+    embed = [":cmd_lib"],
+    deps = [
+        "//pkg/api",
+        "//pkg/api/bazeldnf",
+        "@com_github_onsi_gomega//:gomega",
+    ],
 )

--- a/cmd/config_helper.go
+++ b/cmd/config_helper.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+
+	"github.com/rmohr/bazeldnf/pkg/api"
+	"github.com/rmohr/bazeldnf/pkg/api/bazeldnf"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/maps"
+)
+
+func keys[K cmp.Ordered, V any](m map[K]V) []K {
+	keys := maps.Keys(m)
+	slices.Sort(keys)
+	return keys
+}
+
+func toConfig(install, forceIgnored []*api.Package, targets []string, cmdline []string) (*bazeldnf.Config, error) {
+	ignored := make(map[string]bool)
+	for _, forceIgnoredPackage := range forceIgnored {
+		ignored[forceIgnoredPackage.Name] = true
+	}
+
+	allPackages := make(map[string]*bazeldnf.RPM)
+	repositories := make(map[string][]string)
+	for _, installPackage := range install {
+		repositories[installPackage.Repository.Name] = installPackage.Repository.Mirrors
+
+		deps := make([]string, 0, len(installPackage.Format.Requires.Entries))
+		for _, entry := range installPackage.Format.Requires.Entries {
+			deps = append(deps, entry.Name)
+		}
+
+		slices.Sort(deps)
+
+		allPackages[installPackage.Name] = &bazeldnf.RPM{
+			Name:         installPackage.Name,
+			SHA256:       installPackage.Checksum.Text,
+			URLs:         []string{installPackage.Location.Href},
+			Repository:   installPackage.Repository.Name,
+			Dependencies: deps,
+		}
+	}
+
+	providers := collectProviders(forceIgnored, install)
+	packageNames := keys(allPackages)
+	sortedPackages := make([]*bazeldnf.RPM, 0, len(packageNames))
+	for _, name := range packageNames {
+		pkg := allPackages[name]
+		deps, err := collectDependencies(name, pkg.Dependencies, providers, ignored)
+		if err != nil {
+			return nil, err
+		}
+
+		pkg.SetDependencies(deps)
+
+		sortedPackages = append(sortedPackages, pkg)
+	}
+
+	lockFile := bazeldnf.Config{
+		CommandLineArguments: cmdline,
+		ForceIgnored:         keys(ignored),
+		RPMs:                 sortedPackages,
+		Repositories:         repositories,
+		Targets:              targets,
+	}
+
+	return &lockFile, nil
+}
+
+func collectProviders(pkgSets ...[]*api.Package) map[string]string {
+	providers := map[string]string{}
+	for _, pkgSet := range pkgSets {
+		for _, pkg := range pkgSet {
+			for _, entry := range pkg.Format.Provides.Entries {
+				providers[entry.Name] = pkg.Name
+			}
+
+			for _, entry := range pkg.Format.Files {
+				providers[entry.Text] = pkg.Name
+			}
+		}
+	}
+
+	return providers
+}
+
+func collectDependencies(pkg string, requires []string, providers map[string]string, ignored map[string]bool) ([]string, error) {
+	depSet := make(map[string]bool)
+	for _, req := range requires {
+		if ignored[req] {
+			logrus.Debugf("Ignoring dependency %s", req)
+			continue
+		}
+		logrus.Debugf("Resolving dependency %s", req)
+		provider, ok := providers[req]
+		if !ok {
+			return nil, fmt.Errorf("could not find provider for %s", req)
+		}
+		logrus.Debugf("Found provider %s for %s", provider, req)
+		if ignored[provider] {
+			logrus.Debugf("Ignoring provider %s for %s", provider, req)
+			continue
+		}
+		depSet[provider] = true
+	}
+
+	deps := keys(depSet)
+
+	found := map[string]bool{pkg: true}
+
+	// RPMs may have circular dependencies, even depend on themselves.
+	// we need to ignore such dependencies
+	nonCyclicDeps := make([]string, 0, len(deps))
+	for _, dep := range deps {
+		if found[dep] {
+			continue
+		}
+
+		nonCyclicDeps = append(nonCyclicDeps, dep)
+	}
+
+	return nonCyclicDeps, nil
+}

--- a/cmd/config_helper_test.go
+++ b/cmd/config_helper_test.go
@@ -1,0 +1,432 @@
+package main
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/rmohr/bazeldnf/pkg/api"
+	"github.com/rmohr/bazeldnf/pkg/api/bazeldnf"
+)
+
+func TestBaseCase(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	expected := &bazeldnf.Config{
+		CommandLineArguments: []string{},
+		Name:                 "",
+		Repositories:         map[string][]string{},
+		RPMs:                 []*bazeldnf.RPM{},
+		Targets:              []string{},
+		ForceIgnored:         []string{},
+	}
+	cfg, err := toConfig([]*api.Package{}, []*api.Package{}, []string{}, []string{})
+
+	g.Expect(err).Should(BeNil())
+	g.Expect(cfg).Should(Equal(expected))
+}
+
+func TestSimpleInputs(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ignored := []*api.Package{
+		&api.Package{Name: "package0"},
+		&api.Package{Name: "package1"},
+	}
+	targets := []string{"foo", "bar", "baz"}
+	commandline := []string{"baf", "bam"}
+
+	expected := &bazeldnf.Config{
+		CommandLineArguments: commandline,
+		Name:                 "",
+		Repositories:         map[string][]string{},
+		RPMs:                 []*bazeldnf.RPM{},
+		Targets:              targets,
+		ForceIgnored:         []string{"package0", "package1"},
+	}
+	cfg, err := toConfig([]*api.Package{}, ignored, targets, commandline)
+
+	g.Expect(err).Should(BeNil())
+	g.Expect(cfg).Should(Equal(expected))
+}
+
+func TestMissingProvider(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cfg, err := toConfig(
+		[]*api.Package{
+			newPackageWithDeps("parent", "somedep"),
+		},
+		[]*api.Package{},
+		[]string{},
+		[]string{},
+	)
+
+	g.Expect(err).Should(Equal(errors.New("could not find provider for somedep")))
+	g.Expect(cfg).Should(BeNil())
+}
+
+func newPackage(name, checksum, url, repository string, mirrors []string) *api.Package {
+	return &api.Package{
+		Name:     name,
+		Checksum: api.Checksum{Text: checksum},
+		Location: api.Location{Href: url},
+		Repository: &bazeldnf.Repository{
+			Name:    repository,
+			Mirrors: mirrors,
+		},
+	}
+}
+
+func newSimplePackage(name string) *api.Package {
+	return newPackage(name, "", "", "repository", []string{})
+}
+
+func newPackageWithDeps(name string, deps ...string) *api.Package {
+	p := newSimplePackage(name)
+	entries := []api.Entry{}
+	for _, dep := range deps {
+		entries = append(entries, api.Entry{Name: dep})
+	}
+	p.Format.Requires.Entries = entries
+	p.Format.Provides.Entries = []api.Entry{api.Entry{Name: name}}
+
+	return p
+}
+
+func newPackageWithFiles(name string, files ...string) *api.Package {
+	p := newSimplePackage(name)
+	entries := []api.ProvidedFile{}
+	for _, file := range files {
+		entries = append(entries, api.ProvidedFile{Text: file})
+	}
+	p.Format.Files = entries
+	return p
+}
+
+func newSimpleRPM(name string, deps ...string) *bazeldnf.RPM {
+	d := []string{}
+	if len(deps) > 0 {
+		d = deps
+	}
+
+	return &bazeldnf.RPM{
+		Name:         name,
+		URLs:         []string{""},
+		Repository:   "repository",
+		Dependencies: d,
+	}
+}
+
+func TestConfigTransform(t *testing.T) {
+	tests := []struct {
+		name               string
+		installed, ignored []*api.Package
+
+		expectedRepositories map[string][]string
+		expectedRPMs         []*bazeldnf.RPM
+	}{
+		{
+			name: "one installed",
+			installed: []*api.Package{
+				newPackage(
+					"package0",
+					"mychecksum",
+					"urlforrpm",
+					"repository",
+					[]string{"mirror0", "mirror1"},
+				),
+			},
+			ignored: []*api.Package{},
+			expectedRepositories: map[string][]string{
+				"repository": []string{"mirror0", "mirror1"},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				&bazeldnf.RPM{
+					Name:         "package0",
+					SHA256:       "mychecksum",
+					URLs:         []string{"urlforrpm"},
+					Repository:   "repository",
+					Dependencies: []string{},
+				},
+			},
+		},
+		{
+			name: "two installed",
+			installed: []*api.Package{
+				newPackage(
+					"package0",
+					"mychecksum",
+					"urlforrpm",
+					"repository",
+					[]string{"mirror0", "mirror1"},
+				),
+				newPackage(
+					"package1",
+					"mychecksum0",
+					"urlforrpm0",
+					"repository0",
+					[]string{},
+				),
+			},
+			ignored: []*api.Package{},
+			expectedRepositories: map[string][]string{
+				"repository":  []string{"mirror0", "mirror1"},
+				"repository0": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				&bazeldnf.RPM{
+					Name:         "package0",
+					SHA256:       "mychecksum",
+					URLs:         []string{"urlforrpm"},
+					Repository:   "repository",
+					Dependencies: []string{},
+				},
+				&bazeldnf.RPM{
+					Name:         "package1",
+					SHA256:       "mychecksum0",
+					URLs:         []string{"urlforrpm0"},
+					Repository:   "repository0",
+					Dependencies: []string{},
+				},
+			},
+		},
+		{
+			name: "two installed repo overlap",
+			installed: []*api.Package{
+				newPackage(
+					"package0",
+					"mychecksum",
+					"urlforrpm",
+					"repository",
+					[]string{"mirror0", "mirror1"},
+				),
+				newPackage(
+					"package1",
+					"mychecksum0",
+					"urlforrpm0",
+					"repository",
+					[]string{},
+				),
+			},
+			ignored: []*api.Package{},
+			expectedRepositories: map[string][]string{
+				"repository": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				&bazeldnf.RPM{
+					Name:         "package0",
+					SHA256:       "mychecksum",
+					URLs:         []string{"urlforrpm"},
+					Repository:   "repository",
+					Dependencies: []string{},
+				},
+				&bazeldnf.RPM{
+					Name:         "package1",
+					SHA256:       "mychecksum0",
+					URLs:         []string{"urlforrpm0"},
+					Repository:   "repository",
+					Dependencies: []string{},
+				},
+			},
+		},
+		{
+			name: "two installed out of order",
+			installed: []*api.Package{
+				newSimplePackage("package2"),
+				newSimplePackage("package1"),
+			},
+			ignored: []*api.Package{},
+			expectedRepositories: map[string][]string{
+				"repository": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				newSimpleRPM("package1"),
+				newSimpleRPM("package2"),
+			},
+		},
+		{
+			name: "two installed dep between",
+			installed: []*api.Package{
+				newPackageWithDeps("package1", "package2"),
+				newPackageWithDeps("package2"),
+			},
+			ignored: []*api.Package{},
+			expectedRepositories: map[string][]string{
+				"repository": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				newSimpleRPM("package1", "package2"),
+				newSimpleRPM("package2"),
+			},
+		},
+		{
+			name: "three installed dep from first",
+			installed: []*api.Package{
+				newPackageWithDeps("package1", "package2", "package3"),
+				newPackageWithDeps("package2"),
+				newPackageWithDeps("package3"),
+			},
+			ignored: []*api.Package{},
+			expectedRepositories: map[string][]string{
+				"repository": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				newSimpleRPM("package1", "package2", "package3"),
+				newSimpleRPM("package2"),
+				newSimpleRPM("package3"),
+			},
+		},
+		{
+			name: "three installed dep from first sort deps",
+			installed: []*api.Package{
+				newPackageWithDeps("package1", "package3", "package2"),
+				newPackageWithDeps("package2"),
+				newPackageWithDeps("package3"),
+			},
+			ignored: []*api.Package{},
+			expectedRepositories: map[string][]string{
+				"repository": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				newSimpleRPM("package1", "package2", "package3"),
+				newSimpleRPM("package2"),
+				newSimpleRPM("package3"),
+			},
+		},
+		{
+			name: "three installed dep transitive",
+			installed: []*api.Package{
+				newPackageWithDeps("package1", "package2"),
+				newPackageWithDeps("package2", "package3"),
+				newPackageWithDeps("package3"),
+			},
+			ignored: []*api.Package{},
+			expectedRepositories: map[string][]string{
+				"repository": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				newSimpleRPM("package1", "package2"),
+				newSimpleRPM("package2", "package3"),
+				newSimpleRPM("package3"),
+			},
+		},
+		{
+			name: "three installed dep overlap",
+			installed: []*api.Package{
+				newPackageWithDeps("package1", "package3"),
+				newPackageWithDeps("package2", "package3"),
+				newPackageWithDeps("package3"),
+			},
+			ignored: []*api.Package{},
+			expectedRepositories: map[string][]string{
+				"repository": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				newSimpleRPM("package1", "package3"),
+				newSimpleRPM("package2", "package3"),
+				newSimpleRPM("package3"),
+			},
+		},
+		{
+			name: "two installed require ignored",
+			installed: []*api.Package{
+				newPackageWithDeps("package1", "package2"),
+			},
+			ignored: []*api.Package{
+				newPackageWithDeps("package2"),
+			},
+			expectedRepositories: map[string][]string{
+				"repository": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				newSimpleRPM("package1"),
+			},
+		},
+		{
+			name: "depends on self",
+			installed: []*api.Package{
+				newPackageWithDeps("package1", "package1"),
+			},
+			ignored: []*api.Package{},
+			expectedRepositories: map[string][]string{
+				"repository": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				newSimpleRPM("package1"),
+			},
+		},
+		{
+			name:      "sort ignored",
+			installed: []*api.Package{},
+			ignored: []*api.Package{
+				newPackageWithDeps("package2"),
+				newPackageWithDeps("package1"),
+			},
+			expectedRepositories: map[string][]string{},
+			expectedRPMs:         []*bazeldnf.RPM{},
+		},
+		{
+			name: "file based deps",
+			installed: []*api.Package{
+				newPackageWithDeps("package1", "somefile"),
+				newPackageWithFiles("package2", "somefile"),
+			},
+			ignored: []*api.Package{},
+			expectedRepositories: map[string][]string{
+				"repository": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				newSimpleRPM("package1", "package2"),
+				newSimpleRPM("package2"),
+			},
+		},
+		{
+			name: "file based deps ignored provider",
+			installed: []*api.Package{
+				newPackageWithDeps("package1", "somefile"),
+			},
+			ignored: []*api.Package{
+				newPackageWithFiles("package2", "somefile"),
+			},
+			expectedRepositories: map[string][]string{
+				"repository": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				newSimpleRPM("package1"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			forceIgnored := []string{}
+			for _, pkg := range tt.ignored {
+				forceIgnored = append(forceIgnored, pkg.Name)
+			}
+			slices.Sort(forceIgnored)
+
+			expected := &bazeldnf.Config{
+				CommandLineArguments: []string{},
+				Name:                 "",
+				Repositories:         tt.expectedRepositories,
+				RPMs:                 tt.expectedRPMs,
+				Targets:              []string{},
+				ForceIgnored:         forceIgnored,
+			}
+
+			cfg, err := toConfig(
+				tt.installed,
+				tt.ignored,
+				[]string{},
+				[]string{},
+			)
+
+			g.Expect(err).Should(BeNil())
+			g.Expect(cfg).Should(Equal(expected))
+		})
+	}
+}

--- a/cmd/lockfile.go
+++ b/cmd/lockfile.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+
+	"github.com/rmohr/bazeldnf/pkg/bazel"
+	"github.com/rmohr/bazeldnf/pkg/repo"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type lockfileOpts struct {
+	repofiles      []string
+	configname     string
+	lockfile       string
+}
+
+var lockfileopts = lockfileOpts{}
+
+func NewLockFileCmd() *cobra.Command {
+
+	lockfileCmd := &cobra.Command{
+		Use:   "lockfile",
+		Short: "Manage bazeldnf lock file",
+		Long: `Keep the bazeldnf lock file up to date using a set of dependencies`,
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, required []string) error {
+			repos, err := repo.LoadRepoFiles(lockfileopts.repofiles)
+			if err != nil {
+				return err
+			}
+
+			install, forceIgnored, err := resolve(repos, required)
+			if err != nil {
+				return err
+			}
+
+			logrus.Debugf("install: %v", install)
+			logrus.Debugf("forceIgnored: %v", forceIgnored)
+
+			config, err := toConfig(install, forceIgnored, required, os.Args[2:])
+
+			if err != nil {
+				return err
+			}
+
+			logrus.Info("Writing lockfile.")
+			return bazel.WriteLockFile(config, lockfileopts.lockfile)
+		},
+	}
+
+	addResolveHelperFlags(lockfileCmd)
+	lockfileCmd.Flags().StringArrayVarP(&lockfileopts.repofiles, "repofile", "r", []string{"repo.yaml"}, "repository information file. Can be specified multiple times. Will be used by default if no explicit inputs are provided.")
+	lockfileCmd.Flags().StringVar(&lockfileopts.configname, "configname", "rpms", "config name to use in lockfile")
+	lockfileCmd.Flags().StringVar(&lockfileopts.lockfile, "lockfile", "bazeldnf-lock.json", "lockfile to write to")
+	return lockfileCmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ func Execute() {
 	rootCmd.AddCommand(NewSandboxCmd())
 	rootCmd.AddCommand(NewFetchCmd())
 	rootCmd.AddCommand(NewInitCmd())
+	rootCmd.AddCommand(NewLockFileCmd())
 	rootCmd.AddCommand(NewRpmTreeCmd())
 	rootCmd.AddCommand(NewResolveCmd())
 	rootCmd.AddCommand(NewReduceCmd())

--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -108,7 +108,7 @@ func NewLockFileHandler(configname, filename string) (Handler, error) {
 		filename: filename,
 		config: &bazeldnf.Config{
 			Name: configname,
-			RPMs: []bazeldnf.RPM{},
+			RPMs: []*bazeldnf.RPM{},
 		},
 	}, nil
 }

--- a/pkg/api/bazeldnf/config.go
+++ b/pkg/api/bazeldnf/config.go
@@ -1,12 +1,28 @@
 package bazeldnf
 
 type RPM struct {
-	Name string `json:"name"`
-	SHA256 string `json:"sha256"`
-	URLs []string `json:"urls"`
+	Name         string   `json:"name"`
+	SHA256       string   `json:"sha256"`
+	URLs         []string `json:"urls"`
+	Repository   string   `json:"repository"`
+	Dependencies []string `json:"dependencies"`
+}
+
+func (i *RPM) SetDependencies(pkgs []string) {
+	i.Dependencies = make([]string, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		if pkg == i.Name {
+			continue
+		}
+		i.Dependencies = append(i.Dependencies, pkg)
+	}
 }
 
 type Config struct {
-	Name string `json:"name"`
-	RPMs []RPM `json:"rpms"`
+	CommandLineArguments []string            `json:"cli-arguments,omitempty"`
+	Name                 string              `json:"name"`
+	Repositories         map[string][]string `json:"repositories"`
+	RPMs                 []*RPM              `json:"rpms"`
+	Targets              []string            `json:"targets,omitempty"`
+	ForceIgnored         []string            `json:"ignored,omitempty"`
 }

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -80,7 +80,7 @@ func WriteBzl(dryRun bool, bzl *build.File, path string) error {
 }
 
 func WriteLockFile(config *bazeldnf.Config, path string) error {
-	configJson, err := json.Marshal(config)
+	configJson, err := json.MarshalIndent(config, "", "\t")
 	if err != nil {
 		return err
 	}
@@ -520,7 +520,7 @@ func AddConfigRPMs(config *bazeldnf.Config, pkgs []*api.Package, arch string) er
 
 		config.RPMs = append(
 			config.RPMs,
-			bazeldnf.RPM{
+			&bazeldnf.RPM{
 				Name:   sanitize(pkg.String() + "." + arch),
 				SHA256: pkg.Checksum.Text,
 				URLs:   URLs,


### PR DESCRIPTION
In order to allow for easy generation of the lockfile to use with the rpmtree tags in the bazel module extension we need to add an additional command for this purpose.

The `lockfile` subcommand is derived from a combination  the `rpmtree` subcommand in conjunction with some work from Manuel Naranjo on a `bzlmod` subcommand.

See https://github.com/rmohr/bazeldnf/pull/96 for the `bzlmod` subcommand implementation.