### PR TITLE
wrapper: make the wrapper a bit more portable

### DIFF
--- a/internal/bazeldnf.bzl
+++ b/internal/bazeldnf.bzl
@@ -21,7 +21,7 @@ def _bazeldnf_impl(ctx):
     toolchain = ctx.toolchains[BAZELDNF_TOOLCHAIN]
 
     substitutions = {
-        "@@BAZELDNF_SHORT_PATH@@": shell.quote(toolchain._tool.short_path),
+        "@@BAZELDNF_SHORT_PATH@@": "%s/%s" % (ctx.workspace_name, toolchain._tool.short_path),
         "@@ARGS@@": shell.array_literal(args),
     }
     ctx.actions.expand_template(

--- a/internal/runner.bash.template
+++ b/internal/runner.bash.template
@@ -2,15 +2,12 @@
 
 set -euo pipefail
 
-BAZELDNF_SHORT_PATH=@@BAZELDNF_SHORT_PATH@@
+BAZELDNF_SHORT_PATH="${BASH_SOURCE[0]}.runfiles/@@BAZELDNF_SHORT_PATH@@"
 ARGS=@@ARGS@@
 bazeldnf_short_path=$(readlink "$BAZELDNF_SHORT_PATH")
 
-if [ -z "${BUILD_WORKSPACE_DIRECTORY-}" ]; then
-  echo "error: BUILD_WORKSPACE_DIRECTORY not set" >&2
-  exit 1
+if [ ! -z "${BUILD_WORKSPACE_DIRECTORY-}" ]; then
+  cd ${BUILD_WORKSPACE_DIRECTORY}
 fi
-
-cd ${BUILD_WORKSPACE_DIRECTORY}
 
 "$bazeldnf_short_path" ${ARGS[@]+"${ARGS[@]}"} "$@"


### PR DESCRIPTION
Allow me to run by using the shell file in the bazel-bin directory

Extracted from https://github.com/rmohr/bazeldnf/pull/96