### PR TITLE
Don't ignore repo if arch is empty

### DIFF
--- a/pkg/repo/cache.go
+++ b/pkg/repo/cache.go
@@ -242,7 +242,7 @@ func (r *CacheHelper) CurrentFilelistsForPackages(repo *bazeldnf.Repository, arc
 
 func (r *CacheHelper) CurrentPrimaries(repos *bazeldnf.Repositories, arch string) (primaries []*api.Repository, err error) {
 	for i, repo := range repos.Repositories {
-		if repo.Arch != arch && repo.Arch != "noarch" {
+		if repo.Arch != "" && repo.Arch != arch && repo.Arch != "noarch" {
 			logrus.Infof("Ignoring primary for %s - %s", repo.Name, repo.Arch)
 			continue
 		}


### PR DESCRIPTION
arch isn't a required property and it can be easier to not specify it in the case of, for example, a biarch repo.  This change ensures that if we have not specified the arch the repo is not automatically ignored.