### PR TITLE
Use integrity instead of sha256 for RPMs

### DIFF
--- a/cmd/config_helper.go
+++ b/cmd/config_helper.go
@@ -35,9 +35,14 @@ func toConfig(install, forceIgnored []*api.Package, targets []string, cmdline []
 
 		slices.Sort(deps)
 
+		integrity, err := installPackage.Checksum.Integrity()
+		if err != nil {
+			return nil, fmt.Errorf("Unable to read package %s integrity: %w", installPackage.Name, err)
+		}
+
 		allPackages[installPackage.Name] = &bazeldnf.RPM{
 			Name:         installPackage.Name,
-			SHA256:       installPackage.Checksum.Text,
+			Integrity:    integrity,
 			URLs:         []string{installPackage.Location.Href},
 			Repository:   installPackage.Repository.Name,
 			Dependencies: deps,

--- a/cmd/config_helper_test.go
+++ b/cmd/config_helper_test.go
@@ -70,7 +70,7 @@ func TestMissingProvider(t *testing.T) {
 func newPackage(name, checksum, url, repository string, mirrors []string) *api.Package {
 	return &api.Package{
 		Name:     name,
-		Checksum: api.Checksum{Text: checksum},
+		Checksum: api.Checksum{Text: checksum, Type: "sha256"},
 		Location: api.Location{Href: url},
 		Repository: &bazeldnf.Repository{
 			Name:    repository,
@@ -114,6 +114,7 @@ func newSimpleRPM(name string, deps ...string) *bazeldnf.RPM {
 	return &bazeldnf.RPM{
 		Name:         name,
 		URLs:         []string{""},
+		Integrity:    "sha256-",
 		Repository:   "repository",
 		Dependencies: d,
 	}
@@ -132,7 +133,7 @@ func TestConfigTransform(t *testing.T) {
 			installed: []*api.Package{
 				newPackage(
 					"package0",
-					"mychecksum",
+					"f87b49c517aac9eb4890a4b5005bcc4a586748f2760ea1106382f3897129a60e",
 					"urlforrpm",
 					"repository",
 					[]string{"mirror0", "mirror1"},
@@ -145,7 +146,7 @@ func TestConfigTransform(t *testing.T) {
 			expectedRPMs: []*bazeldnf.RPM{
 				&bazeldnf.RPM{
 					Name:         "package0",
-					SHA256:       "mychecksum",
+					Integrity:    "sha256-+HtJxReqyetIkKS1AFvMSlhnSPJ2DqEQY4LziXEppg4=",
 					URLs:         []string{"urlforrpm"},
 					Repository:   "repository",
 					Dependencies: []string{},
@@ -157,14 +158,14 @@ func TestConfigTransform(t *testing.T) {
 			installed: []*api.Package{
 				newPackage(
 					"package0",
-					"mychecksum",
+					"f87b49c517aac9eb4890a4b5005bcc4a586748f2760ea1106382f3897129a60e",
 					"urlforrpm",
 					"repository",
 					[]string{"mirror0", "mirror1"},
 				),
 				newPackage(
 					"package1",
-					"mychecksum0",
+					"9146a02ed928ffca6ef0f1241d2d86e4e998e6f70aae875754601fda54951fbd",
 					"urlforrpm0",
 					"repository0",
 					[]string{},
@@ -178,14 +179,14 @@ func TestConfigTransform(t *testing.T) {
 			expectedRPMs: []*bazeldnf.RPM{
 				&bazeldnf.RPM{
 					Name:         "package0",
-					SHA256:       "mychecksum",
+					Integrity:    "sha256-+HtJxReqyetIkKS1AFvMSlhnSPJ2DqEQY4LziXEppg4=",
 					URLs:         []string{"urlforrpm"},
 					Repository:   "repository",
 					Dependencies: []string{},
 				},
 				&bazeldnf.RPM{
 					Name:         "package1",
-					SHA256:       "mychecksum0",
+					Integrity:    "sha256-kUagLtko/8pu8PEkHS2G5OmY5vcKrodXVGAf2lSVH70=",
 					URLs:         []string{"urlforrpm0"},
 					Repository:   "repository0",
 					Dependencies: []string{},
@@ -197,14 +198,14 @@ func TestConfigTransform(t *testing.T) {
 			installed: []*api.Package{
 				newPackage(
 					"package0",
-					"mychecksum",
+					"f87b49c517aac9eb4890a4b5005bcc4a586748f2760ea1106382f3897129a60e",
 					"urlforrpm",
 					"repository",
 					[]string{"mirror0", "mirror1"},
 				),
 				newPackage(
 					"package1",
-					"mychecksum0",
+					"9146a02ed928ffca6ef0f1241d2d86e4e998e6f70aae875754601fda54951fbd",
 					"urlforrpm0",
 					"repository",
 					[]string{},
@@ -217,14 +218,14 @@ func TestConfigTransform(t *testing.T) {
 			expectedRPMs: []*bazeldnf.RPM{
 				&bazeldnf.RPM{
 					Name:         "package0",
-					SHA256:       "mychecksum",
+					Integrity:    "sha256-+HtJxReqyetIkKS1AFvMSlhnSPJ2DqEQY4LziXEppg4=",
 					URLs:         []string{"urlforrpm"},
 					Repository:   "repository",
 					Dependencies: []string{},
 				},
 				&bazeldnf.RPM{
 					Name:         "package1",
-					SHA256:       "mychecksum0",
+					Integrity:    "sha256-kUagLtko/8pu8PEkHS2G5OmY5vcKrodXVGAf2lSVH70=",
 					URLs:         []string{"urlforrpm0"},
 					Repository:   "repository",
 					Dependencies: []string{},

--- a/e2e/bazel-bzlmod-lock-file-from-args/bazeldnf-lock.json
+++ b/e2e/bazel-bzlmod-lock-file-from-args/bazeldnf-lock.json
@@ -32,7 +32,7 @@
 	"rpms": [
 		{
 			"name": "bash",
-			"sha256": "05dc1b806bd5456d40e3d7f882ead037aaf480c596e83fbfb6ab86be74a2d8d1",
+			"integrity": "sha256-BdwbgGvVRW1A49f4gurQN6r0gMWW6D+/tquGvnSi2NE=",
 			"urls": [
 				"bash-5.1.8-9.el9.x86_64.rpm"
 			],
@@ -43,7 +43,7 @@
 		},
 		{
 			"name": "ncurses-base",
-			"sha256": "d8307bfbd2428c8d08deffaff1ec61f7bc016ef03c77798b32ce021965e1bc65",
+			"integrity": "sha256-2DB7+9JCjI0I3v+v8exh97wBbvA8d3mLMs4CGWXhvGU=",
 			"urls": [
 				"ncurses-base-6.2-10.20210508.el9.noarch.rpm"
 			],
@@ -52,7 +52,7 @@
 		},
 		{
 			"name": "ncurses-libs",
-			"sha256": "d06b0e491481a345faf21a69666cbdc302d19b54fb29ae1aa78fa6b205f9e604",
+			"integrity": "sha256-0GsOSRSBo0X68hppZmy9wwLRm1T7Ka4ap4+msgX55gQ=",
 			"urls": [
 				"ncurses-libs-6.2-10.20210508.el9.x86_64.rpm"
 			],

--- a/e2e/bazel-bzlmod-lock-file/rpms-with-no-name-attribute.json
+++ b/e2e/bazel-bzlmod-lock-file/rpms-with-no-name-attribute.json
@@ -1,9 +1,9 @@
 {
     "rpms": [
         {
-            "sha256": "aac272a2ace134b5ef60a41e6624deb24331e79c76699ef6cef0dca22d94ac7e",
+            "integrity": "sha256-qsJyoqzhNLXvYKQeZiTeskMx55x2aZ72zvDcoi2UrH4=",
             "urls": [
-		"https://kojipkgs.fedoraproject.org/packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm"
+		"libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm"
             ],
 	    "repository": "foo"
         }

--- a/e2e/bazel-bzlmod-lock-file/rpms.json
+++ b/e2e/bazel-bzlmod-lock-file/rpms.json
@@ -3,16 +3,16 @@
     "rpms": [
         {
             "name": "libvirt-libs",
-            "sha256": "aac272a2ace134b5ef60a41e6624deb24331e79c76699ef6cef0dca22d94ac7e",
+            "integrity": "sha256-qsJyoqzhNLXvYKQeZiTeskMx55x2aZ72zvDcoi2UrH4=",
             "urls": [
-		"https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm"
+		"libvirt/11.0.0/1.fc42/x86_64/libvirt-libs-11.0.0-1.fc42.x86_64.rpm"
             ],
 	    "repository": "foo"
         },
         {
-            "sha256": "dba37bbe57903afe49b5666f1781eb50001baa81af4584b355db0b6a2afad9fa",
+            "integrity": "sha256-26N7vleQOv5JtWZvF4HrUAAbqoGvRYSzVdsLair62fo=",
             "urls": [
-		"https://kojipkgs.fedoraproject.org//packages/libvirt/11.0.0/1.fc42/x86_64/libvirt-devel-11.0.0-1.fc42.x86_64.rpm"
+		"libvirt/11.0.0/1.fc42/x86_64/libvirt-devel-11.0.0-1.fc42.x86_64.rpm"
             ],
 	    "repository": "foo"
         }

--- a/e2e/bzlmod-toolchain-circular-dependencies/bazeldnf-lock.json
+++ b/e2e/bzlmod-toolchain-circular-dependencies/bazeldnf-lock.json
@@ -26,7 +26,7 @@
 	"rpms": [
 		{
 			"name": "audit-libs",
-			"sha256": "d1482f65e84e761f0282e9e2c2a7111f0638dc889d6f34e4cde160e465855d1e",
+			"integrity": "sha256-0UgvZehOdh8CguniwqcRHwY43IidbzTkzeFg5GWFXR4=",
 			"urls": [
 				"Packages/audit-libs-3.1.5-4.el9.x86_64.rpm"
 			],
@@ -38,7 +38,7 @@
 		},
 		{
 			"name": "bash",
-			"sha256": "823859a9e8fad83004fa0d9f698ff223f6f7d38fd8e7629509d98b5ba6764c03",
+			"integrity": "sha256-gjhZqej62DAE+g2faY/yI/b304/Y52KVCdmLW6Z2TAM=",
 			"urls": [
 				"Packages/bash-5.1.8-9.el9.x86_64.rpm"
 			],
@@ -51,7 +51,7 @@
 		},
 		{
 			"name": "bzip2-libs",
-			"sha256": "84392815cc1a8f01c651edd17f570aa449ef6f397ae48d773d655606ea7b4c96",
+			"integrity": "sha256-hDkoFcwajwHGUe3Rf1cKpEnvbzl65I13PWVWBup7TJY=",
 			"urls": [
 				"Packages/bzip2-libs-1.0.8-10.el9.x86_64.rpm"
 			],
@@ -62,7 +62,7 @@
 		},
 		{
 			"name": "ca-certificates",
-			"sha256": "d18c1b9763c22dc93da804f96ad3d92b3157195c9eff6e923c33e9011df3e246",
+			"integrity": "sha256-0Ywbl2PCLck9qAT5atPZKzFXGVye/26SPDPpAR3z4kY=",
 			"urls": [
 				"Packages/ca-certificates-2024.2.69_v8.0.303-91.4.el9.noarch.rpm"
 			],
@@ -77,7 +77,7 @@
 		},
 		{
 			"name": "centos-gpg-keys",
-			"sha256": "8d601d9f96356a200ad6ed8e5cb49bbac4aa3c4b762d10a23e11311daa5711ca",
+			"integrity": "sha256-jWAdn5Y1aiAK1u2OXLSbusSqPEt2LRCiPhExHapXEco=",
 			"urls": [
 				"Packages/centos-gpg-keys-9.0-26.el9.noarch.rpm"
 			],
@@ -86,7 +86,7 @@
 		},
 		{
 			"name": "centos-stream-release",
-			"sha256": "3d60dc8ed86717f68394fc7468b8024557c43ac2ad97b8e40911d056cd6d64d3",
+			"integrity": "sha256-PWDcjthnF/aDlPx0aLgCRVfEOsKtl7jkCRHQVs1tZNM=",
 			"urls": [
 				"Packages/centos-stream-release-9.0-26.el9.noarch.rpm"
 			],
@@ -97,7 +97,7 @@
 		},
 		{
 			"name": "centos-stream-repos",
-			"sha256": "eb3b55a5cf0e1a93a91cd2d39035bd1754b46f69ff3d062b3331e765b2345035",
+			"integrity": "sha256-6ztVpc8OGpOpHNLTkDW9F1S0b2n/PQYrMzHnZbI0UDU=",
 			"urls": [
 				"Packages/centos-stream-repos-9.0-26.el9.noarch.rpm"
 			],
@@ -108,7 +108,7 @@
 		},
 		{
 			"name": "coreutils",
-			"sha256": "2afe3e8ef2b82e75ad5a735994d3a877bda13ac0ec7ef92f0ec5205b7451e95c",
+			"integrity": "sha256-Kv4+jvK4LnWtWnNZlNOod72hOsDsfvkvDsUgW3RR6Vw=",
 			"urls": [
 				"Packages/coreutils-8.32-39.el9.x86_64.rpm"
 			],
@@ -126,7 +126,7 @@
 		},
 		{
 			"name": "coreutils-common",
-			"sha256": "7e0a2ae2601cbfe8811e6c3c2bc10de303a4138a48b0407bc21f929876b54fb2",
+			"integrity": "sha256-fgoq4mAcv+iBHmw8K8EN4wOkE4pIsEB7wh+SmHa1T7I=",
 			"urls": [
 				"Packages/coreutils-common-8.32-39.el9.x86_64.rpm"
 			],
@@ -135,7 +135,7 @@
 		},
 		{
 			"name": "cracklib",
-			"sha256": "be9deb2efd06b4b2c1c130acae94c687161d04830119e65a989d904ba9fd1864",
+			"integrity": "sha256-vp3rLv0GtLLBwTCsrpTGhxYdBIMBGeZamJ2QS6n9GGQ=",
 			"urls": [
 				"Packages/cracklib-2.9.6-27.el9.x86_64.rpm"
 			],
@@ -149,7 +149,7 @@
 		},
 		{
 			"name": "cracklib-dicts",
-			"sha256": "01df2a72fcdf988132e82764ce1a22a5a9513fa253b54e17d23058bdb53c2d85",
+			"integrity": "sha256-Ad8qcvzfmIEy6CdkzhoipalRP6JTtU4X0jBYvbU8LYU=",
 			"urls": [
 				"Packages/cracklib-dicts-2.9.6-27.el9.x86_64.rpm"
 			],
@@ -160,7 +160,7 @@
 		},
 		{
 			"name": "crypto-policies",
-			"sha256": "f811d2c848f6f93a188f2d74d4ccd172e1dc88fa7919e8e203cf1df3d93571e1",
+			"integrity": "sha256-+BHSyEj2+ToYjy101MzRcuHciPp5GejiA88d89k1ceE=",
 			"urls": [
 				"Packages/crypto-policies-20250128-1.git5269e22.el9.noarch.rpm"
 			],
@@ -171,16 +171,16 @@
 		},
 		{
 			"name": "emacs-filesystem",
-			"sha256": "1b5841ddc4862a7e52f29534ed42eb84d8ed4b2dd969be68fabe475c75aa955f",
+			"integrity": "sha256-jJsTruBTK9i8zl8o+4GH0IXA2qPTBm485ts5OpDimdk=",
 			"urls": [
-				"Packages/emacs-filesystem-27.2-10.el9.noarch.rpm"
+				"Packages/emacs-filesystem-27.2-13.el9.noarch.rpm"
 			],
 			"repository": "centos-stream-9-stable-appstream",
 			"dependencies": []
 		},
 		{
 			"name": "expat",
-			"sha256": "360ed994ea2af5b3a7f37694dfdf2249d97e5e5ec2492c9223a2aec72ff8f480",
+			"integrity": "sha256-Ng7ZlOoq9bOn83aU398iSdl+Xl7CSSySI6Kuxy/49IA=",
 			"urls": [
 				"Packages/expat-2.5.0-4.el9.x86_64.rpm"
 			],
@@ -191,7 +191,7 @@
 		},
 		{
 			"name": "filesystem",
-			"sha256": "da7750fc31248ecc606016391c3f570e1abe7422f812b29a49d830c71884e6dc",
+			"integrity": "sha256-2ndQ/DEkjsxgYBY5HD9XDhq+dCL4ErKaSdgwxxiE5tw=",
 			"urls": [
 				"Packages/filesystem-3.16-5.el9.x86_64.rpm"
 			],
@@ -203,7 +203,7 @@
 		},
 		{
 			"name": "gawk",
-			"sha256": "6e6d77b76b1e89fe6f012cdc16111bea35eb4ceedac5040e5d81b5a066429af8",
+			"integrity": "sha256-bm13t2seif5vASzcFhEb6jXrTO7axQQOXYG1oGZCmvg=",
 			"urls": [
 				"Packages/gawk-5.1.0-6.el9.x86_64.rpm"
 			],
@@ -219,7 +219,7 @@
 		},
 		{
 			"name": "git",
-			"sha256": "973bcf0bf47568f0b1871faed0ac4a15eaaf9ee354da35b0ddfe8cc08f40004c",
+			"integrity": "sha256-lzvPC/R1aPCxhx+u0KxKFeqvnuNU2jWw3f6MwI9AAEw=",
 			"urls": [
 				"Packages/git-2.47.1-1.el9.x86_64.rpm"
 			],
@@ -243,7 +243,7 @@
 		},
 		{
 			"name": "git-core",
-			"sha256": "9e39f1ddef47d848f97595701d0b4657f3eefafa6cae5953d503d132ca38f3a1",
+			"integrity": "sha256-njnx3e9H2Ej5dZVwHQtGV/Pu+vpsrllT1QPRMso486E=",
 			"urls": [
 				"Packages/git-core-2.47.1-1.el9.x86_64.rpm"
 			],
@@ -262,7 +262,7 @@
 		},
 		{
 			"name": "git-core-doc",
-			"sha256": "ab9166f73f102ceef3187f52aa940deee49dd68b15430dbe4889b0ddedf2431e",
+			"integrity": "sha256-q5Fm9z8QLO7zGH9SqpQN7uSd1osVQw2+SImw3e3yQx4=",
 			"urls": [
 				"Packages/git-core-doc-2.47.1-1.el9.noarch.rpm"
 			],
@@ -273,7 +273,7 @@
 		},
 		{
 			"name": "glibc",
-			"sha256": "e06212b1cac1d9fd9857a00ddefefe9fb9f406199cb84fdd1153589c15e16289",
+			"integrity": "sha256-4GISscrB2f2YV6AN3v7+n7n0BhmcuE/dEVNYnBXhYok=",
 			"urls": [
 				"Packages/glibc-2.34-168.el9.x86_64.rpm"
 			],
@@ -286,7 +286,7 @@
 		},
 		{
 			"name": "glibc-all-langpacks",
-			"sha256": "a1714ab74c097094aad9808a48e21c57f3876fa3de5f247b10197d7c8a2de8b8",
+			"integrity": "sha256-oXFKt0wJcJSq2YCKSOIcV/OHb6PeXyR7EBl9fIot6Lg=",
 			"urls": [
 				"Packages/glibc-all-langpacks-2.34-168.el9.x86_64.rpm"
 			],
@@ -298,7 +298,7 @@
 		},
 		{
 			"name": "glibc-common",
-			"sha256": "531650744909efd0284bf6c16a45dbaf455b214c0cac4197cf6d43e8c7d83af8",
+			"integrity": "sha256-UxZQdEkJ79AoS/bBakXbr0VbIUwMrEGXz21D6MfYOvg=",
 			"urls": [
 				"Packages/glibc-common-2.34-168.el9.x86_64.rpm"
 			],
@@ -311,7 +311,7 @@
 		},
 		{
 			"name": "gmp",
-			"sha256": "b6d592895ccc0fcad6106cd41800cd9d68e5384c418e53a2c3ff2ac8c8b15a33",
+			"integrity": "sha256-ttWSiVzMD8rWEGzUGADNnWjlOExBjlOiw/8qyMixWjM=",
 			"urls": [
 				"Packages/gmp-6.2.0-13.el9.x86_64.rpm"
 			],
@@ -322,7 +322,7 @@
 		},
 		{
 			"name": "grep",
-			"sha256": "10a41b66b1fbd6eb055178e22c37199e5b49b4852e77c806f7af7211044a4a55",
+			"integrity": "sha256-EKQbZrH71usFUXjiLDcZnltJtIUud8gG969yEQRKSlU=",
 			"urls": [
 				"Packages/grep-3.6-5.el9.x86_64.rpm"
 			],
@@ -336,7 +336,7 @@
 		},
 		{
 			"name": "groff-base",
-			"sha256": "f8f02725766bef0fdf3db124d7862848e692518ce04919fb1a583f013bbbabfb",
+			"integrity": "sha256-+PAnJXZr7w/fPbEk14YoSOaSUYzgSRn7Glg/ATu7q/s=",
 			"urls": [
 				"Packages/groff-base-1.22.4-10.el9.x86_64.rpm"
 			],
@@ -350,7 +350,7 @@
 		},
 		{
 			"name": "gzip",
-			"sha256": "e8d7783c666a58ab870246b04eb0ea22965123fe284697d2c0e1e6dbf10ea861",
+			"integrity": "sha256-6Nd4PGZqWKuHAkawTrDqIpZRI/4oRpfSwOHm2/EOqGE=",
 			"urls": [
 				"Packages/gzip-1.12-1.el9.x86_64.rpm"
 			],
@@ -363,7 +363,7 @@
 		},
 		{
 			"name": "keyutils-libs",
-			"sha256": "aef982501694486a27411c68698886d76ec70c5cd10bfe619501e7e4c36f50a9",
+			"integrity": "sha256-rvmCUBaUSGonQRxoaYiG127HDFzRC/5hlQHn5MNvUKk=",
 			"urls": [
 				"Packages/keyutils-libs-1.6.3-1.el9.x86_64.rpm"
 			],
@@ -374,7 +374,7 @@
 		},
 		{
 			"name": "krb5-libs",
-			"sha256": "50edf4089d0480048aeba2bfd736b93aa89dc25735cd02e80bad57e562e1e001",
+			"integrity": "sha256-UO30CJ0EgASK66K/1za5Oqidwlc1zQLoC61X5WLh4AE=",
 			"urls": [
 				"Packages/krb5-libs-1.21.1-6.el9.x86_64.rpm"
 			],
@@ -396,7 +396,7 @@
 		},
 		{
 			"name": "less",
-			"sha256": "46e11dfacb75a8d03047d82f44ae46b11d95da31e0ec1b3a8cc37a132b1c7cae",
+			"integrity": "sha256-RuEd+st1qNAwR9gvRK5GsR2V2jHg7Bs6jMN6EyscfK4=",
 			"urls": [
 				"Packages/less-590-5.el9.x86_64.rpm"
 			],
@@ -409,7 +409,7 @@
 		},
 		{
 			"name": "libacl",
-			"sha256": "60a3affaa1c387fd6f72dd65aa7ad619a1830947823abb4b29e7b9fcb4c9d27c",
+			"integrity": "sha256-YKOv+qHDh/1vct1lqnrWGaGDCUeCOrtLKee5/LTJ0nw=",
 			"urls": [
 				"Packages/libacl-2.3.1-4.el9.x86_64.rpm"
 			],
@@ -421,7 +421,7 @@
 		},
 		{
 			"name": "libattr",
-			"sha256": "d4db095a015e84065f27a642ee7829cd1690041ba8c51501f908cc34760c9409",
+			"integrity": "sha256-1NsJWgFehAZfJ6ZC7ngpzRaQBBuoxRUB+QjMNHYMlAk=",
 			"urls": [
 				"Packages/libattr-2.5.1-3.el9.x86_64.rpm"
 			],
@@ -432,7 +432,7 @@
 		},
 		{
 			"name": "libblkid",
-			"sha256": "2433f8829f894c7c5ba0639eb37a18a92632d4f9383551c901434b4353f96fc4",
+			"integrity": "sha256-JDP4gp+JTHxboGOes3oYqSYy1Pk4NVHJAUNLQ1P5b8Q=",
 			"urls": [
 				"Packages/libblkid-2.37.4-21.el9.x86_64.rpm"
 			],
@@ -446,7 +446,7 @@
 		},
 		{
 			"name": "libcap",
-			"sha256": "7d07ec8a6a0975d84c66adf21c885c41a5571ecb631055959265c60fda314111",
+			"integrity": "sha256-fQfsimoJddhMZq3yHIhcQaVXHstjEFWVkmXGD9oxQRE=",
 			"urls": [
 				"Packages/libcap-2.48-9.el9.x86_64.rpm"
 			],
@@ -458,7 +458,7 @@
 		},
 		{
 			"name": "libcap-ng",
-			"sha256": "62429b788acfb40dbc9da9951690c11e907e230879c790d139f73d0e85dd76f4",
+			"integrity": "sha256-YkKbeIrPtA28namVFpDBHpB+Iwh5x5DROfc9DoXddvQ=",
 			"urls": [
 				"Packages/libcap-ng-0.8.2-7.el9.x86_64.rpm"
 			],
@@ -469,7 +469,7 @@
 		},
 		{
 			"name": "libcbor",
-			"sha256": "ecbb61df93e6816276712d02a3013c591a8b58a8ef50ece98d814564565980ab",
+			"integrity": "sha256-7Lth35PmgWJ2cS0CowE8WRqLWKjvUOzpjYFFZFZZgKs=",
 			"urls": [
 				"Packages/libcbor-0.7.0-5.el9.x86_64.rpm"
 			],
@@ -480,7 +480,7 @@
 		},
 		{
 			"name": "libcom_err",
-			"sha256": "d11e18dbfddd56538c476851d98bd96795f34045e14ebe7b3285f225c4b4b189",
+			"integrity": "sha256-0R4Y2/3dVlOMR2hR2YvZZ5XzQEXhTr57MoXyJcS0sYk=",
 			"urls": [
 				"Packages/libcom_err-1.46.5-7.el9.x86_64.rpm"
 			],
@@ -491,7 +491,7 @@
 		},
 		{
 			"name": "libcurl-minimal",
-			"sha256": "6438485e38465ee944e25abedcf4a1761564fe5202f05a02c71e4c880255b539",
+			"integrity": "sha256-ZDhIXjhGXulE4lq+3PShdhVk/lIC8FoCxx5MiAJVtTk=",
 			"urls": [
 				"Packages/libcurl-minimal-7.76.1-31.el9.x86_64.rpm"
 			],
@@ -507,7 +507,7 @@
 		},
 		{
 			"name": "libdb",
-			"sha256": "e28608db5eaa3ee38e8bc0d6be1831048da1e638920a6f16a8084e72e2ebf6c9",
+			"integrity": "sha256-4oYI216qPuOOi8DWvhgxBI2h5jiSCm8WqAhOcuLr9sk=",
 			"urls": [
 				"Packages/libdb-5.3.28-55.el9.x86_64.rpm"
 			],
@@ -518,7 +518,7 @@
 		},
 		{
 			"name": "libeconf",
-			"sha256": "ed519cc2e9031e2bf03275b28c7cca6520ae916d0a7edbbc69f327c1b70ed6cc",
+			"integrity": "sha256-7VGcwukDHivwMnWyjHzKZSCukW0Kftu8afMnwbcO1sw=",
 			"urls": [
 				"Packages/libeconf-0.4.1-4.el9.x86_64.rpm"
 			],
@@ -529,7 +529,7 @@
 		},
 		{
 			"name": "libedit",
-			"sha256": "bfa91ff96f312b284a16a91b2eabcdae9e43c2f9b698fee6eec94040eaef8f7e",
+			"integrity": "sha256-v6kf+W8xKyhKFqkbLqvNrp5Dwvm2mP7m7slAQOrvj34=",
 			"urls": [
 				"Packages/libedit-3.1-38.20210216cvs.el9.x86_64.rpm"
 			],
@@ -541,7 +541,7 @@
 		},
 		{
 			"name": "libfdisk",
-			"sha256": "9a594c51e3bf09cb5016485ee2f143de6db960ff1c7e135c0097f59fa51b2edb",
+			"integrity": "sha256-mllMUeO/CctQFkhe4vFD3m25YP8cfhNcAJf1n6UbLts=",
 			"urls": [
 				"Packages/libfdisk-2.37.4-21.el9.x86_64.rpm"
 			],
@@ -554,7 +554,7 @@
 		},
 		{
 			"name": "libffi",
-			"sha256": "110d5008364a65b38b832949970886fdccb97762b0cdb257571cc0c84182d7d0",
+			"integrity": "sha256-EQ1QCDZKZbOLgylJlwiG/cy5d2KwzbJXVxzAyEGC19A=",
 			"urls": [
 				"Packages/libffi-3.4.2-8.el9.x86_64.rpm"
 			],
@@ -565,7 +565,7 @@
 		},
 		{
 			"name": "libfido2",
-			"sha256": "85c3a84335d833069f5758b34f4636313ffc0d5ca7f73d24e05fd566735c5cd6",
+			"integrity": "sha256-hcOoQzXYMwafV1izT0Y2MT/8DVyn9z0k4F/VZnNcXNY=",
 			"urls": [
 				"Packages/libfido2-1.13.0-2.el9.x86_64.rpm"
 			],
@@ -580,7 +580,7 @@
 		},
 		{
 			"name": "libgcc",
-			"sha256": "442c065a815212ac21760ff9f0bd93e9f5d5972925d9e987a421cbf6ebba41d2",
+			"integrity": "sha256-RCwGWoFSEqwhdg/58L2T6fXVlykl2emHpCHL9uu6QdI=",
 			"urls": [
 				"Packages/libgcc-11.5.0-5.el9.x86_64.rpm"
 			],
@@ -589,7 +589,7 @@
 		},
 		{
 			"name": "libgcrypt",
-			"sha256": "0323a74a5ad27bc3dc4ac4e9565825f37dc58b2a4800adbf33f767fa7a267c35",
+			"integrity": "sha256-AyOnSlrSe8PcSsTpVlgl833FiypIAK2/M/dn+nomfDU=",
 			"urls": [
 				"Packages/libgcrypt-1.10.0-11.el9.x86_64.rpm"
 			],
@@ -601,7 +601,7 @@
 		},
 		{
 			"name": "libgpg-error",
-			"sha256": "a1883804c376f737109f4dff06077d1912b90150a732d11be7bc5b3b67e512fe",
+			"integrity": "sha256-oYg4BMN29zcQn03/Bgd9GRK5AVCnMtEb57xbO2flEv4=",
 			"urls": [
 				"Packages/libgpg-error-1.42-5.el9.x86_64.rpm"
 			],
@@ -612,7 +612,7 @@
 		},
 		{
 			"name": "libmount",
-			"sha256": "d8bfc70d1a9a594569c8c95bda682804a20bb4ee602db3efa7b6e76d289ecc66",
+			"integrity": "sha256-2L/HDRqaWUVpyMlb2mgoBKILtO5gLbPvp7bnbSiezGY=",
 			"urls": [
 				"Packages/libmount-2.37.4-21.el9.x86_64.rpm"
 			],
@@ -626,7 +626,7 @@
 		},
 		{
 			"name": "libnghttp2",
-			"sha256": "fc1cadbc6cf37cbea60112b7ae6f92fabfd5a7f76fa526bb5a1ea82746455ec7",
+			"integrity": "sha256-/BytvGzzfL6mARK3rm+S+r/Vp/dvpSa7Wh6oJ0ZFXsc=",
 			"urls": [
 				"Packages/libnghttp2-1.43.0-6.el9.x86_64.rpm"
 			],
@@ -637,7 +637,7 @@
 		},
 		{
 			"name": "libpwquality",
-			"sha256": "93f00e5efac1e3f1ecbc0d6a4c068772cb12912cd20c9ea58716d6c0cd004886",
+			"integrity": "sha256-k/AOXvrB4/HsvA1qTAaHcssSkSzSDJ6lhxbWwM0ASIY=",
 			"urls": [
 				"Packages/libpwquality-1.4.4-8.el9.x86_64.rpm"
 			],
@@ -651,7 +651,7 @@
 		},
 		{
 			"name": "libselinux",
-			"sha256": "79abe72ea8dccb4134286fd1aae79827f10bde0cc1c35224886e93b293d282d1",
+			"integrity": "sha256-eavnLqjcy0E0KG/RqueYJ/EL3gzBw1IkiG6TspPSgtE=",
 			"urls": [
 				"Packages/libselinux-3.6-3.el9.x86_64.rpm"
 			],
@@ -664,9 +664,9 @@
 		},
 		{
 			"name": "libsemanage",
-			"sha256": "f8d235c4c3aedb484203472f164efd77cc9b55679556817a0afeb59dac4cc8b9",
+			"integrity": "sha256-Pc9ufyd5Q02dx67wBlw6KXd5IXAmSmDUMk9mJbuc1po=",
 			"urls": [
-				"Packages/libsemanage-3.6-4.el9.x86_64.rpm"
+				"Packages/libsemanage-3.6-5.el9.x86_64.rpm"
 			],
 			"repository": "centos-stream-9-stable-baseos",
 			"dependencies": [
@@ -679,7 +679,7 @@
 		},
 		{
 			"name": "libsepol",
-			"sha256": "7a1c10a4512624dfc1b76da45b7a0d15f8ecdddf20c9738b10ca12df7f488ae1",
+			"integrity": "sha256-ehwQpFEmJN/Bt22kW3oNFfjs3d8gyXOLEMoS339IiuE=",
 			"urls": [
 				"Packages/libsepol-3.6-2.el9.x86_64.rpm"
 			],
@@ -690,7 +690,7 @@
 		},
 		{
 			"name": "libsigsegv",
-			"sha256": "931bd0ec7050e8c3b37a9bfb489e30af32486a3c77203f1e9113eeceaa3b0a3a",
+			"integrity": "sha256-kxvQ7HBQ6MOzepv7SJ4wrzJIajx3ID8ekRPuzqo7Cjo=",
 			"urls": [
 				"Packages/libsigsegv-2.13-4.el9.x86_64.rpm"
 			],
@@ -701,7 +701,7 @@
 		},
 		{
 			"name": "libsmartcols",
-			"sha256": "30e2a071ad6f1939f14fc89c827d61ccb28a6cbf6e443db39e8019a18c7e18d4",
+			"integrity": "sha256-MOKgca1vGTnxT8icgn1hzLKKbL9uRD2znoAZoYx+GNQ=",
 			"urls": [
 				"Packages/libsmartcols-2.37.4-21.el9.x86_64.rpm"
 			],
@@ -712,7 +712,7 @@
 		},
 		{
 			"name": "libstdc++",
-			"sha256": "6628a0027a113c8687d0cd52ed5725ee6cb1ee2a02897349289d683fc6453223",
+			"integrity": "sha256-ZiigAnoRPIaH0M1S7Vcl7myx7ioCiXNJKJ1oP8ZFMiM=",
 			"urls": [
 				"Packages/libstdc++-11.5.0-5.el9.x86_64.rpm"
 			],
@@ -724,7 +724,7 @@
 		},
 		{
 			"name": "libtasn1",
-			"sha256": "addd155d4abc41529d7e8588f442e50a87db3a1314bd2162fbb4950d898a2e28",
+			"integrity": "sha256-rd0VXUq8QVKdfoWI9ELlCofbOhMUvSFi+7SVDYmKLig=",
 			"urls": [
 				"Packages/libtasn1-4.16.0-9.el9.x86_64.rpm"
 			],
@@ -735,7 +735,7 @@
 		},
 		{
 			"name": "libutempter",
-			"sha256": "fab361a9cba04490fd8b5664049983d1e57ebf7c1080804726ba600708524125",
+			"integrity": "sha256-+rNhqcugRJD9i1ZkBJmD0eV+v3wQgIBHJrpgBwhSQSU=",
 			"urls": [
 				"Packages/libutempter-1.2.1-6.el9.x86_64.rpm"
 			],
@@ -748,7 +748,7 @@
 		},
 		{
 			"name": "libuuid",
-			"sha256": "be4793be5af11772206abe023746ec4021a8b7bc124fdc7e7cdb92b57c46d125",
+			"integrity": "sha256-vkeTvlrxF3Igar4CN0bsQCGot7wST9x+fNuStXxG0SU=",
 			"urls": [
 				"Packages/libuuid-2.37.4-21.el9.x86_64.rpm"
 			],
@@ -759,7 +759,7 @@
 		},
 		{
 			"name": "libverto",
-			"sha256": "c55578b84f169c4ed79b2d50ea03fd1817007e35062c9fe7a58e6cad025f3b24",
+			"integrity": "sha256-xVV4uE8WnE7Xmy1Q6gP9GBcAfjUGLJ/npY5srQJfOyQ=",
 			"urls": [
 				"Packages/libverto-0.3.2-3.el9.x86_64.rpm"
 			],
@@ -770,7 +770,7 @@
 		},
 		{
 			"name": "libxcrypt",
-			"sha256": "97e88678b420f619a44608fff30062086aa1dd6931ecbd54f21bba005ff1de1a",
+			"integrity": "sha256-l+iGeLQg9hmkRgj/8wBiCGqh3Wkx7L1U8hu6AF/x3ho=",
 			"urls": [
 				"Packages/libxcrypt-4.4.18-3.el9.x86_64.rpm"
 			],
@@ -781,7 +781,7 @@
 		},
 		{
 			"name": "libzstd",
-			"sha256": "3439a7437a4b47ef4b6efbcd8c5862180fb281dd956d70a4ffe3764fd8d997dd",
+			"integrity": "sha256-NDmnQ3pLR+9LbvvNjFhiGA+ygd2VbXCk/+N2T9jZl90=",
 			"urls": [
 				"Packages/libzstd-1.5.5-1.el9.x86_64.rpm"
 			],
@@ -792,7 +792,7 @@
 		},
 		{
 			"name": "lz4-libs",
-			"sha256": "cba6a63054d070956a182e33269ee245bcfbe87e3e605c27816519db762a66ad",
+			"integrity": "sha256-y6amMFTQcJVqGC4zJp7iRbz76H4+YFwngWUZ23YqZq0=",
 			"urls": [
 				"Packages/lz4-libs-1.9.3-5.el9.x86_64.rpm"
 			],
@@ -803,7 +803,7 @@
 		},
 		{
 			"name": "mpfr",
-			"sha256": "179760104aa5a31ca463c586d0f21f380ba4d0eed212eee91bd1ca513e5d7a8d",
+			"integrity": "sha256-F5dgEEqloxykY8WG0PIfOAuk0O7SEu7pG9HKUT5deo0=",
 			"urls": [
 				"Packages/mpfr-4.1.0-7.el9.x86_64.rpm"
 			],
@@ -815,7 +815,7 @@
 		},
 		{
 			"name": "ncurses",
-			"sha256": "45d743dcda5be230bae12ef3f883f75e87295993ee4a0f277c31f691022eac30",
+			"integrity": "sha256-RddD3Npb4jC64S7z+IP3XocpWZPuSg8nfDH2kQIurDA=",
 			"urls": [
 				"Packages/ncurses-6.2-10.20210508.el9.x86_64.rpm"
 			],
@@ -827,7 +827,7 @@
 		},
 		{
 			"name": "ncurses-base",
-			"sha256": "00ba56b28a3a85c3c03387bb7abeca92597c8a5fac7f53d48410ca2a20fd8065",
+			"integrity": "sha256-ALpWsoo6hcPAM4e7er7Kkll8il+sf1PUhBDKKiD9gGU=",
 			"urls": [
 				"Packages/ncurses-base-6.2-10.20210508.el9.noarch.rpm"
 			],
@@ -836,7 +836,7 @@
 		},
 		{
 			"name": "ncurses-libs",
-			"sha256": "f4ead70a508051ed338499b35605b5b2b5bccde19c9e83f7e4b948f171b542ff",
+			"integrity": "sha256-9OrXClCAUe0zhJmzVgW1srW8zeGcnoP35LlI8XG1Qv8=",
 			"urls": [
 				"Packages/ncurses-libs-6.2-10.20210508.el9.x86_64.rpm"
 			],
@@ -848,7 +848,7 @@
 		},
 		{
 			"name": "openssh",
-			"sha256": "4f2c1a6290b3c0ad2afcb47d44b1d6e2523810fd0bfbc4b754682a27dbf2b6a3",
+			"integrity": "sha256-TywaYpCzwK0q/LR9RLHW4lI4EP0L+8S3VGgqJ9vytqM=",
 			"urls": [
 				"Packages/openssh-8.7p1-45.el9.x86_64.rpm"
 			],
@@ -866,7 +866,7 @@
 		},
 		{
 			"name": "openssh-clients",
-			"sha256": "4e93ea43133c9c10bbcccc8e55b4cba8e4b00b3c76597d64c3b1e54b4d3653ca",
+			"integrity": "sha256-TpPqQxM8nBC7zMyOVbTLqOSwCzx2WX1kw7HlS002U8o=",
 			"urls": [
 				"Packages/openssh-clients-8.7p1-45.el9.x86_64.rpm"
 			],
@@ -887,7 +887,7 @@
 		},
 		{
 			"name": "openssl",
-			"sha256": "3018c5d2901213b6bdbe62301ef894008ec52b1122e270190eabb62ad282a46a",
+			"integrity": "sha256-MBjF0pASE7a9vmIwHviUAI7FKxEi4nAZDqu2KtKCpGo=",
 			"urls": [
 				"Packages/openssl-3.2.2-6.el9.x86_64.rpm"
 			],
@@ -901,7 +901,7 @@
 		},
 		{
 			"name": "openssl-libs",
-			"sha256": "4a0a29a309f72ba65a2d0b2d4b51637253520f6a0a1bd4640f0a09f7d7555738",
+			"integrity": "sha256-Sgopown3K6ZaLQstS1FjclNSD2oKG9RkDwoJ99dVVzg=",
 			"urls": [
 				"Packages/openssl-libs-3.2.2-6.el9.x86_64.rpm"
 			],
@@ -915,7 +915,7 @@
 		},
 		{
 			"name": "p11-kit",
-			"sha256": "2d02f32cdb62fac32563c70fad44c7252f0173552ccabc58d2b5161207c291a3",
+			"integrity": "sha256-LQLzLNti+sMlY8cPrUTHJS8Bc1UsyrxY0rUWEgfCkaM=",
 			"urls": [
 				"Packages/p11-kit-0.25.3-3.el9.x86_64.rpm"
 			],
@@ -928,7 +928,7 @@
 		},
 		{
 			"name": "p11-kit-trust",
-			"sha256": "f3b18cc69d79899e17d7c7514a4e350bdd6166a37e979fee5dcfbdc7921a02fa",
+			"integrity": "sha256-87GMxp15iZ4X18dRSk41C91hZqN+l5/uXc+9x5IaAvo=",
 			"urls": [
 				"Packages/p11-kit-trust-0.25.3-3.el9.x86_64.rpm"
 			],
@@ -942,7 +942,7 @@
 		},
 		{
 			"name": "pam",
-			"sha256": "fba392096cbf59204549bca23d4060cdf8aaaa9ce35ade8194c111f519033e10",
+			"integrity": "sha256-+6OSCWy/WSBFSbyiPUBgzfiqqpzjWt6BlMER9RkDPhA=",
 			"urls": [
 				"Packages/pam-1.5.1-23.el9.x86_64.rpm"
 			],
@@ -962,7 +962,7 @@
 		},
 		{
 			"name": "pcre",
-			"sha256": "7d6be1d41cb4d0b159a764bfc7c8efecc0353224b46e5286cbbea7092b700690",
+			"integrity": "sha256-fWvh1By00LFZp2S/x8jv7MA1MiS0blKGy76nCStwBpA=",
 			"urls": [
 				"Packages/pcre-8.44-4.el9.x86_64.rpm"
 			],
@@ -973,7 +973,7 @@
 		},
 		{
 			"name": "pcre2",
-			"sha256": "bc1012f5417aab8393836d78ac8c5472b1a2d84a2f9fa2b00fff5f8ad3a5ec26",
+			"integrity": "sha256-vBAS9UF6q4OTg214rIxUcrGi2Eovn6KwD/9fitOl7CY=",
 			"urls": [
 				"Packages/pcre2-10.40-6.el9.x86_64.rpm"
 			],
@@ -985,7 +985,7 @@
 		},
 		{
 			"name": "pcre2-syntax",
-			"sha256": "be36a84f6e311a59190664d61a466471391ab01fb77bd1d2348e9a76414aded4",
+			"integrity": "sha256-vjaoT24xGlkZBmTWGkZkcTkasB+3e9HSNI6adkFK3tQ=",
 			"urls": [
 				"Packages/pcre2-syntax-10.40-6.el9.noarch.rpm"
 			],
@@ -994,7 +994,7 @@
 		},
 		{
 			"name": "perl-AutoLoader",
-			"sha256": "f0bcf4a04a62b163c6c80006d604117cf5a825756ce39ef1bd0818ae848aa2cf",
+			"integrity": "sha256-8Lz0oEpisWPGyAAG1gQRfPWoJXVs457xvQgYroSKos8=",
 			"urls": [
 				"Packages/perl-AutoLoader-5.74-481.el9.noarch.rpm"
 			],
@@ -1006,7 +1006,7 @@
 		},
 		{
 			"name": "perl-B",
-			"sha256": "df7b0c3048ffbe05d0ff6dafc45f0af7da189579204c3be8d2872a04a6794dff",
+			"integrity": "sha256-33sMMEj/vgXQ/22vxF8K99oYlXkgTDvo0ocqBKZ5Tf8=",
 			"urls": [
 				"Packages/perl-B-1.80-481.el9.x86_64.rpm"
 			],
@@ -1022,7 +1022,7 @@
 		},
 		{
 			"name": "perl-Carp",
-			"sha256": "f1ca6aaa47ef96d6b47f20f3a2df2ce530228790f2c0330ece567cc77ddd5063",
+			"integrity": "sha256-8cpqqkfvlta0fyDzot8s5TAih5DywDMOzlZ8x33dUGM=",
 			"urls": [
 				"Packages/perl-Carp-1.50-460.el9.noarch.rpm"
 			],
@@ -1034,7 +1034,7 @@
 		},
 		{
 			"name": "perl-Class-Struct",
-			"sha256": "74119bd904503f9c57cbc2c254b14e08406115a04c1253e2207372cab59be1ee",
+			"integrity": "sha256-dBGb2QRQP5xXy8LCVLFOCEBhFaBMElPiIHNyyrWb4e4=",
 			"urls": [
 				"Packages/perl-Class-Struct-0.66-481.el9.noarch.rpm"
 			],
@@ -1047,7 +1047,7 @@
 		},
 		{
 			"name": "perl-Data-Dumper",
-			"sha256": "f979d2efed136001fe0d54632b626b53842c281f9354408e0f7c75bcfc408f67",
+			"integrity": "sha256-+XnS7+0TYAH+DVRjK2JrU4QsKB+TVECOD3x1vPxAj2c=",
 			"urls": [
 				"Packages/perl-Data-Dumper-2.174-462.el9.x86_64.rpm"
 			],
@@ -1064,7 +1064,7 @@
 		},
 		{
 			"name": "perl-Digest",
-			"sha256": "de4b71c1cf818d48940ca0f68f5d3c520a321affe9e33b5afd7976c811f1d741",
+			"integrity": "sha256-3ktxwc+BjUiUDKD2j108UgoyGv/p4zta/Xl2yBHx10E=",
 			"urls": [
 				"Packages/perl-Digest-1.19-4.el9.noarch.rpm"
 			],
@@ -1078,7 +1078,7 @@
 		},
 		{
 			"name": "perl-Digest-MD5",
-			"sha256": "ec7e38c29105e1502a13e8e13f9bc1b1bc02a21babf02e95a6966b40a8d8cbaa",
+			"integrity": "sha256-7H44wpEF4VAqE+jhP5vBsbwCohur8C6VppZrQKjYy6o=",
 			"urls": [
 				"Packages/perl-Digest-MD5-2.58-4.el9.x86_64.rpm"
 			],
@@ -1092,7 +1092,7 @@
 		},
 		{
 			"name": "perl-DynaLoader",
-			"sha256": "ed74238c99a8f69d799f31c60bb4faf07fa625080dbc7335962104ab63159a79",
+			"integrity": "sha256-7XQjjJmo9p15nzHGC7T68H+mJQgNvHM1liEEq2MVmnk=",
 			"urls": [
 				"Packages/perl-DynaLoader-1.47-481.el9.x86_64.rpm"
 			],
@@ -1104,7 +1104,7 @@
 		},
 		{
 			"name": "perl-Encode",
-			"sha256": "85db7859711b30f268305ad0b3cdab68c8072fdf6ba60725a49657d6ae001bea",
+			"integrity": "sha256-hdt4WXEbMPJoMFrQs82raMgHL99rpgclpJZX1q4AG+o=",
 			"urls": [
 				"Packages/perl-Encode-3.08-462.el9.x86_64.rpm"
 			],
@@ -1128,7 +1128,7 @@
 		},
 		{
 			"name": "perl-Errno",
-			"sha256": "8a770d19c48537606dd8ae50cd24c9a48f3ebe999ff9b6aa23f08602031c5ee3",
+			"integrity": "sha256-incNGcSFN2Bt2K5QzSTJpI8+vpmf+baqI/CGAgMcXuM=",
 			"urls": [
 				"Packages/perl-Errno-1.30-481.el9.x86_64.rpm"
 			],
@@ -1141,7 +1141,7 @@
 		},
 		{
 			"name": "perl-Error",
-			"sha256": "4a81617ae4e3718fed9af76711d0d4ab4c3cea7c5f10b26b704dd2a15d6ca2d5",
+			"integrity": "sha256-SoFheuTjcY/tmvdnEdDUq0w86nxfELJrcE3SoV1sotU=",
 			"urls": [
 				"Packages/perl-Error-0.17029-7.el9.noarch.rpm"
 			],
@@ -1157,7 +1157,7 @@
 		},
 		{
 			"name": "perl-Exporter",
-			"sha256": "1fefc5a7bc8cd31a853c090cdaa0758344cacc56561532dfef20ab70bd30bcab",
+			"integrity": "sha256-H+/Fp7yM0xqFPAkM2qB1g0TKzFZWFTLf7yCrcL0wvKs=",
 			"urls": [
 				"Packages/perl-Exporter-5.74-461.el9.noarch.rpm"
 			],
@@ -1169,7 +1169,7 @@
 		},
 		{
 			"name": "perl-Fcntl",
-			"sha256": "d2a8667eb4319d9c44aca8493c8fc84148eeb2d5e23aa22297210c1de1fd7846",
+			"integrity": "sha256-0qhmfrQxnZxErKhJPI/IQUjustXiOqIilyEMHeH9eEY=",
 			"urls": [
 				"Packages/perl-Fcntl-1.13-481.el9.x86_64.rpm"
 			],
@@ -1182,7 +1182,7 @@
 		},
 		{
 			"name": "perl-File-Basename",
-			"sha256": "c78ac06d4f6eb825091d3e3dae448a429cb4711b1ddf6c75fdf00946ec09fd7d",
+			"integrity": "sha256-x4rAbU9uuCUJHT49rkSKQpy0cRsd32x1/fAJRuwJ/X0=",
 			"urls": [
 				"Packages/perl-File-Basename-2.85-481.el9.noarch.rpm"
 			],
@@ -1195,7 +1195,7 @@
 		},
 		{
 			"name": "perl-File-Find",
-			"sha256": "7ee4e0c4817b825be165e663bc03f1c8ee45e872b8fb6b8968355bae1622e61e",
+			"integrity": "sha256-fuTgxIF7glvhZeZjvAPxyO5F6HK4+2uJaDVbrhYi5h4=",
 			"urls": [
 				"Packages/perl-File-Find-1.37-481.el9.noarch.rpm"
 			],
@@ -1209,7 +1209,7 @@
 		},
 		{
 			"name": "perl-File-Path",
-			"sha256": "74b7f75cf3c8bf7191a8e6d88689d7aca1b1f60d56c890ead7d558a704a4a4cc",
+			"integrity": "sha256-dLf3XPPIv3GRqObYhonXrKGx9g1WyJDq19VYpwSkpMw=",
 			"urls": [
 				"Packages/perl-File-Path-2.18-4.el9.noarch.rpm"
 			],
@@ -1225,7 +1225,7 @@
 		},
 		{
 			"name": "perl-File-Temp",
-			"sha256": "a1416670c051fdf7ea5e7ffac059d88e17b14a61cf75a95be6e3c6d2e730101b",
+			"integrity": "sha256-oUFmcMBR/ffqXn/6wFnYjhexSmHPdalb5uPG0ucwEBs=",
 			"urls": [
 				"Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm"
 			],
@@ -1248,7 +1248,7 @@
 		},
 		{
 			"name": "perl-File-stat",
-			"sha256": "93e3e03bd8bdf7df40657e591daa94671ff3576cd88954e054e47adc27032c8e",
+			"integrity": "sha256-k+PgO9i9999AZX5ZHaqUZx/zV2zYiVTgVOR63CcDLI4=",
 			"urls": [
 				"Packages/perl-File-stat-1.09-481.el9.noarch.rpm"
 			],
@@ -1266,7 +1266,7 @@
 		},
 		{
 			"name": "perl-FileHandle",
-			"sha256": "8424b7cec06428cfbe888d9d9a68a752dfd78466dbcb4e86114469fb034584d0",
+			"integrity": "sha256-hCS3zsBkKM++iI2dmminUt/XhGbby06GEURp+wNFhNA=",
 			"urls": [
 				"Packages/perl-FileHandle-2.03-481.el9.noarch.rpm"
 			],
@@ -1279,7 +1279,7 @@
 		},
 		{
 			"name": "perl-Getopt-Long",
-			"sha256": "0053d63a5eb0bc399e2e56a2599a1a09dca20c5bcac36f713a56fec46abac391",
+			"integrity": "sha256-AFPWOl6wvDmeLlaiWZoaCdyiDFvKw29xOlb+xGq6w5E=",
 			"urls": [
 				"Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm"
 			],
@@ -1296,7 +1296,7 @@
 		},
 		{
 			"name": "perl-Getopt-Std",
-			"sha256": "6694398c32de4a6f27904be25c4b76536ed9f0c9781c946ad48a41d39f067a05",
+			"integrity": "sha256-ZpQ5jDLeSm8nkEviXEt2U27Z8Ml4HJRq1IpB058GegU=",
 			"urls": [
 				"Packages/perl-Getopt-Std-1.12-481.el9.noarch.rpm"
 			],
@@ -1308,7 +1308,7 @@
 		},
 		{
 			"name": "perl-Git",
-			"sha256": "cc185dd15a5b7787cb1a5f93456b3ebe271f9286f667579f33d76f13bc17f882",
+			"integrity": "sha256-zBhd0Vpbd4fLGl+TRWs+vicfkob2Z1efM9dvE7wX+II=",
 			"urls": [
 				"Packages/perl-Git-2.47.1-1.el9.noarch.rpm"
 			],
@@ -1323,7 +1323,7 @@
 		},
 		{
 			"name": "perl-HTTP-Tiny",
-			"sha256": "8579bcd4112b973c3bd072db832e26c4d04eb984952892c01ef7119b18ccbf50",
+			"integrity": "sha256-hXm81BErlzw70HLbgy4mxNBOuYSVKJLAHvcRmxjMv1A=",
 			"urls": [
 				"Packages/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm"
 			],
@@ -1344,7 +1344,7 @@
 		},
 		{
 			"name": "perl-IO",
-			"sha256": "127c53f8c005ee3098e52e197ae1c7ffbfc6c35373de7d43c1c042932f148d9b",
+			"integrity": "sha256-EnxT+MAF7jCY5S4ZeuHH/7/Gw1Nz3n1DwcBCky8UjZs=",
 			"urls": [
 				"Packages/perl-IO-1.43-481.el9.x86_64.rpm"
 			],
@@ -1365,7 +1365,7 @@
 		},
 		{
 			"name": "perl-IO-Socket-IP",
-			"sha256": "95babe1d96f2dfd85f161d3f82bb3ba4ad4a2591d0d90919132f1358377f53bf",
+			"integrity": "sha256-lbq+HZby39hfFh0/grs7pK1KJZHQ2QkZEy8TWDd/U78=",
 			"urls": [
 				"Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm"
 			],
@@ -1383,7 +1383,7 @@
 		},
 		{
 			"name": "perl-IO-Socket-SSL",
-			"sha256": "e52de538f131646122dccc4985b63d448ef1c641543fac2df066b31798e16131",
+			"integrity": "sha256-5S3lOPExZGEi3MxJhbY9RI7xxkFUP6wt8GazF5jhYTE=",
 			"urls": [
 				"Packages/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm"
 			],
@@ -1406,7 +1406,7 @@
 		},
 		{
 			"name": "perl-IPC-Open3",
-			"sha256": "56f9cc438951140a1aa2662556c1259d9a2b4d80d8e11e756165e72e29d61cb3",
+			"integrity": "sha256-VvnMQ4lRFAoaomYlVsElnZorTYDY4R51YWXnLinWHLM=",
 			"urls": [
 				"Packages/perl-IPC-Open3-1.21-481.el9.noarch.rpm"
 			],
@@ -1424,7 +1424,7 @@
 		},
 		{
 			"name": "perl-MIME-Base64",
-			"sha256": "ce4d4eeb8e4524212437ac964d9f0b6ba562c7064a7bf976bec5836e87e20cd2",
+			"integrity": "sha256-zk1O645FJCEkN6yWTZ8La6VixwZKe/l2vsWDbofiDNI=",
 			"urls": [
 				"Packages/perl-MIME-Base64-3.16-4.el9.x86_64.rpm"
 			],
@@ -1437,7 +1437,7 @@
 		},
 		{
 			"name": "perl-Mozilla-CA",
-			"sha256": "27dfc72f604506654c671d164852668094da5e817e84b8192f21e29429a59838",
+			"integrity": "sha256-J9/HL2BFBmVMZx0WSFJmgJTaXoF+hLgZLyHilCmlmDg=",
 			"urls": [
 				"Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm"
 			],
@@ -1450,7 +1450,7 @@
 		},
 		{
 			"name": "perl-Net-SSLeay",
-			"sha256": "d806dde5e3e7b6b3cacdf81c13f590c466b1ad003b18e62e1c0cbbfdd277198f",
+			"integrity": "sha256-2Abd5ePntrPKzfgcE/WQxGaxrQA7GOYuHAy7/dJ3GY8=",
 			"urls": [
 				"Packages/perl-Net-SSLeay-1.94-1.el9.x86_64.rpm"
 			],
@@ -1470,7 +1470,7 @@
 		},
 		{
 			"name": "perl-POSIX",
-			"sha256": "d2e68e82c34d405f85e48609df07c6ae72cc65df181e2b3e0bc8139fe32a2c30",
+			"integrity": "sha256-0uaOgsNNQF+F5IYJ3wfGrnLMZd8YHis+C8gTn+MqLDA=",
 			"urls": [
 				"Packages/perl-POSIX-1.94-481.el9.x86_64.rpm"
 			],
@@ -1485,7 +1485,7 @@
 		},
 		{
 			"name": "perl-PathTools",
-			"sha256": "0ef613a8fe3d9e2355a7b063f1cd5d019772c837e2435c9efcd7ea925ad27024",
+			"integrity": "sha256-DvYTqP49niNVp7Bj8c1dAZdyyDfiQ1ye/NfqklrScCQ=",
 			"urls": [
 				"Packages/perl-PathTools-3.78-461.el9.x86_64.rpm"
 			],
@@ -1502,7 +1502,7 @@
 		},
 		{
 			"name": "perl-Pod-Escapes",
-			"sha256": "c32ad4f02ecad264d2337837848706cc44f0502f39d978a6c055166fcf8ce917",
+			"integrity": "sha256-wyrU8C7K0mTSM3g3hIcGzETwUC852XimwFUWb8+M6Rc=",
 			"urls": [
 				"Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm"
 			],
@@ -1515,7 +1515,7 @@
 		},
 		{
 			"name": "perl-Pod-Perldoc",
-			"sha256": "fb38583786c1d851fe160de0e436ae2bb332f60e072a6e58db02b2affb9aab6c",
+			"integrity": "sha256-+zhYN4bB2FH+Fg3g5DauK7My9g4HKm5Y2wKyr/uaq2w=",
 			"urls": [
 				"Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm"
 			],
@@ -1543,7 +1543,7 @@
 		},
 		{
 			"name": "perl-Pod-Simple",
-			"sha256": "4b70575a9f0ebc0f0026681112532243b0699ca7dc5dcb165cef856adc1ec0d8",
+			"integrity": "sha256-S3BXWp8OvA8AJmgRElMiQ7BpnKfcXcsWXO+FatwewNg=",
 			"urls": [
 				"Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm"
 			],
@@ -1565,7 +1565,7 @@
 		},
 		{
 			"name": "perl-Pod-Usage",
-			"sha256": "2dded1efa254118c646affd59615237825f00e36b86a96a98fd59c8b6015612a",
+			"integrity": "sha256-Ld7R76JUEYxkav/VlhUjeCXwDja4apapj9Wci2AVYSo=",
 			"urls": [
 				"Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm"
 			],
@@ -1583,7 +1583,7 @@
 		},
 		{
 			"name": "perl-Scalar-List-Utils",
-			"sha256": "e3a54464f1aebb25a2ab046307c3d6a032bbed64f493e4ece521d3801d1db48e",
+			"integrity": "sha256-46VEZPGuuyWiqwRjB8PWoDK77WT0k+Ts5SHTgB0dtI4=",
 			"urls": [
 				"Packages/perl-Scalar-List-Utils-1.56-462.el9.x86_64.rpm"
 			],
@@ -1597,7 +1597,7 @@
 		},
 		{
 			"name": "perl-SelectSaver",
-			"sha256": "49802d6bc0a5053f036f9df4b543d73d3184841303d7866d801879627aad32a4",
+			"integrity": "sha256-SYAta8ClBT8Db530tUPXPTGEhBMD14ZtgBh5YnqtMqQ=",
 			"urls": [
 				"Packages/perl-SelectSaver-1.02-481.el9.noarch.rpm"
 			],
@@ -1610,7 +1610,7 @@
 		},
 		{
 			"name": "perl-Socket",
-			"sha256": "356cc16228b97a64af8b2548661ab69277b32a30663da29727ee62a2503c3cec",
+			"integrity": "sha256-NWzBYii5emSviyVIZhq2knezKjBmPaKXJ+5iolA8POw=",
 			"urls": [
 				"Packages/perl-Socket-2.031-4.el9.x86_64.rpm"
 			],
@@ -1624,7 +1624,7 @@
 		},
 		{
 			"name": "perl-Storable",
-			"sha256": "027c042137acf66ded0de52859610be36373ccd555dc30a865a31267c22c5579",
+			"integrity": "sha256-AnwEITes9m3tDeUoWWEL42NzzNVV3DCoZaMSZ8IsVXk=",
 			"urls": [
 				"Packages/perl-Storable-3.21-460.el9.x86_64.rpm"
 			],
@@ -1640,7 +1640,7 @@
 		},
 		{
 			"name": "perl-Symbol",
-			"sha256": "ae09bd7adc2d490c6d09ddc2ecc4a012e5e740f1d7785390af1e810cc2d0e41c",
+			"integrity": "sha256-rgm9etwtSQxtCd3C7MSgEuXnQPHXeFOQrx6BDMLQ5Bw=",
 			"urls": [
 				"Packages/perl-Symbol-1.08-481.el9.noarch.rpm"
 			],
@@ -1652,7 +1652,7 @@
 		},
 		{
 			"name": "perl-Term-ANSIColor",
-			"sha256": "d4e87c795780fa190baba5291c390e9af304e4f134e4aa4f2d03fc9b91ca5d60",
+			"integrity": "sha256-1Oh8eVeA+hkLq6UpHDkOmvME5PE05KpPLQP8m5HKXWA=",
 			"urls": [
 				"Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm"
 			],
@@ -1664,7 +1664,7 @@
 		},
 		{
 			"name": "perl-Term-Cap",
-			"sha256": "5c38c53e562f24cbdb395b11358efaaf6aee82ccd385055c5ffcf1843593d8da",
+			"integrity": "sha256-XDjFPlYvJMvbOVsRNY76r2rugszThQVcX/zxhDWT2No=",
 			"urls": [
 				"Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm"
 			],
@@ -1678,7 +1678,7 @@
 		},
 		{
 			"name": "perl-TermReadKey",
-			"sha256": "187f79672b11692f5cd1fdddd07708856442818accfa120bee40be3e5b6b3cff",
+			"integrity": "sha256-GH95ZysRaS9c0f3d0HcIhWRCgYrM+hIL7kC+PltrPP8=",
 			"urls": [
 				"Packages/perl-TermReadKey-2.38-11.el9.x86_64.rpm"
 			],
@@ -1693,7 +1693,7 @@
 		},
 		{
 			"name": "perl-Text-ParseWords",
-			"sha256": "1264dd35d5deda51b4431955b2838cd18e0012dc27f0e0cb65061324216ff22c",
+			"integrity": "sha256-EmTdNdXe2lG0QxlVsoOM0Y4AEtwn8ODLZQYTJCFv8iw=",
 			"urls": [
 				"Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm"
 			],
@@ -1706,7 +1706,7 @@
 		},
 		{
 			"name": "perl-Text-Tabs+Wrap",
-			"sha256": "11966231d2834b2a9c2c0bf2af231e1257ce030da1cfecdd16d08a6a23222b24",
+			"integrity": "sha256-EZZiMdKDSyqcLAvyryMeElfOAw2hz+zdFtCKaiMiKyQ=",
 			"urls": [
 				"Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm"
 			],
@@ -1719,7 +1719,7 @@
 		},
 		{
 			"name": "perl-Time-Local",
-			"sha256": "53f9616f9c60c8fb7befeff87f5b76c61ee75686a6c289f394c4793d3692de3b",
+			"integrity": "sha256-U/lhb5xgyPt77+/4f1t2xh7nVoamwonzlMR5PTaS3js=",
 			"urls": [
 				"Packages/perl-Time-Local-1.300-7.el9.noarch.rpm"
 			],
@@ -1734,7 +1734,7 @@
 		},
 		{
 			"name": "perl-URI",
-			"sha256": "745f84fc781c84763cad8001841711d6142eb13f50e55de928d3d051a0435ef2",
+			"integrity": "sha256-dF+E/HgchHY8rYABhBcR1hQusT9Q5V3pKNPQUaBDXvI=",
 			"urls": [
 				"Packages/perl-URI-5.09-3.el9.noarch.rpm"
 			],
@@ -1756,7 +1756,7 @@
 		},
 		{
 			"name": "perl-base",
-			"sha256": "7e9df641c5022b8247d85db7daddc45812d1bf70db0c7c5d2e88d83ee2fd15ac",
+			"integrity": "sha256-fp32QcUCK4JH2F232t3EWBLRv3DbDHxdLojYPuL9Faw=",
 			"urls": [
 				"Packages/perl-base-2.27-481.el9.noarch.rpm"
 			],
@@ -1768,7 +1768,7 @@
 		},
 		{
 			"name": "perl-constant",
-			"sha256": "6a25cfb9d83c69bd767be0e30de26dbc9ece902c9e848965c3378ef1405ceb6e",
+			"integrity": "sha256-aiXPudg8ab12e+DjDeJtvJ7OkCyehIllwzeO8UBc624=",
 			"urls": [
 				"Packages/perl-constant-1.33-461.el9.noarch.rpm"
 			],
@@ -1780,7 +1780,7 @@
 		},
 		{
 			"name": "perl-if",
-			"sha256": "5dd5c42ecd5ac27e2a1652598cb9153788353cfb75541f58538a2590269ee7fc",
+			"integrity": "sha256-XdXELs1awn4qFlJZjLkVN4g1PPt1VB9YU4olkCae5/w=",
 			"urls": [
 				"Packages/perl-if-0.60.800-481.el9.noarch.rpm"
 			],
@@ -1791,7 +1791,7 @@
 		},
 		{
 			"name": "perl-interpreter",
-			"sha256": "b40999c1ca1ab5b5f64370fa637e11fb16f8128aa8ba273e4f61847e4b83b2bd",
+			"integrity": "sha256-tAmZwcoatbX2Q3D6Y34R+xb4Eoqouic+T2GEfkuDsr0=",
 			"urls": [
 				"Packages/perl-interpreter-5.32.1-481.el9.x86_64.rpm"
 			],
@@ -1803,7 +1803,7 @@
 		},
 		{
 			"name": "perl-lib",
-			"sha256": "51ad0ac921129ff109c7ee476bad6c52fedb8326ee3be78c3f1dba7b5f2ed6bb",
+			"integrity": "sha256-Ua0KySESn/EJx+5Ha61sUv7bgybuO+eMPx26e18u1rs=",
 			"urls": [
 				"Packages/perl-lib-0.65-481.el9.x86_64.rpm"
 			],
@@ -1815,7 +1815,7 @@
 		},
 		{
 			"name": "perl-libnet",
-			"sha256": "b882c8742426d278d387432a65220bd63ffd1670737aea43084994d2b638e5d4",
+			"integrity": "sha256-uILIdCQm0njTh0MqZSIL1j/9FnBzeupDCEmU0rY45dQ=",
 			"urls": [
 				"Packages/perl-libnet-3.13-4.el9.noarch.rpm"
 			],
@@ -1840,7 +1840,7 @@
 		},
 		{
 			"name": "perl-libs",
-			"sha256": "94dbe5048327048d2717eca240eb740b8ea1932e3802d865ae1dce8c4297a938",
+			"integrity": "sha256-lNvlBIMnBI0nF+yiQOt0C46hky44Athlrh3OjEKXqTg=",
 			"urls": [
 				"Packages/perl-libs-5.32.1-481.el9.x86_64.rpm"
 			],
@@ -1856,7 +1856,7 @@
 		},
 		{
 			"name": "perl-mro",
-			"sha256": "5a6f47a06e17462e8950ef058b570acba679f3d2afda3f08a3e83fc86b9ff6c6",
+			"integrity": "sha256-Wm9HoG4XRi6JUO8Fi1cKy6Z589Kv2j8Io+g/yGuf9sY=",
 			"urls": [
 				"Packages/perl-mro-1.23-481.el9.x86_64.rpm"
 			],
@@ -1868,7 +1868,7 @@
 		},
 		{
 			"name": "perl-overload",
-			"sha256": "9831611e4c117f4aae928eca474f677f325300e32dd4f793d218bbb36c0f8dc5",
+			"integrity": "sha256-mDFhHkwRf0quko7KR09nfzJTAOMt1PeT0hi7s2wPjcU=",
 			"urls": [
 				"Packages/perl-overload-1.31-481.el9.noarch.rpm"
 			],
@@ -1882,7 +1882,7 @@
 		},
 		{
 			"name": "perl-overloading",
-			"sha256": "50a627c576ff19b6dda692c92b421cad7a85157cd71d393752acc623f7f89580",
+			"integrity": "sha256-UKYnxXb/GbbdppLJK0IcrXqFFXzXHTk3UqzGI/f4lYA=",
 			"urls": [
 				"Packages/perl-overloading-0.02-481.el9.noarch.rpm"
 			],
@@ -1894,7 +1894,7 @@
 		},
 		{
 			"name": "perl-parent",
-			"sha256": "342a7b84a44cd59bea045f679309ef6145a235897dedb8a9afd2d015bc17f72a",
+			"integrity": "sha256-NCp7hKRM1ZvqBF9nkwnvYUWiNYl97bipr9LQFbwX9yo=",
 			"urls": [
 				"Packages/perl-parent-0.238-460.el9.noarch.rpm"
 			],
@@ -1905,7 +1905,7 @@
 		},
 		{
 			"name": "perl-podlators",
-			"sha256": "aac9b4c1ccd942afaec19299880eb89e1889b4531e7cab751c3be6a66f9c5fa6",
+			"integrity": "sha256-qsm0wczZQq+uwZKZiA64nhiJtFMefKt1HDvmpm+cX6Y=",
 			"urls": [
 				"Packages/perl-podlators-4.14-460.el9.noarch.rpm"
 			],
@@ -1930,7 +1930,7 @@
 		},
 		{
 			"name": "perl-subs",
-			"sha256": "d7fc5bfd239714499eb2e492eeee2eb63e6173846efca39c2f42f85d2f3fa6d7",
+			"integrity": "sha256-1/xb/SOXFEmesuSS7u4utj5hc4Ru/KOcL0L4XS8/ptc=",
 			"urls": [
 				"Packages/perl-subs-1.03-481.el9.noarch.rpm"
 			],
@@ -1941,7 +1941,7 @@
 		},
 		{
 			"name": "perl-vars",
-			"sha256": "36e5771fb53423efdd1875f034a4d7e08434a5780ab7be45fb6e32925e68b1ad",
+			"integrity": "sha256-NuV3H7U0I+/dGHXwNKTX4IQ0pXgKt75F+24ykl5osa0=",
 			"urls": [
 				"Packages/perl-vars-1.05-481.el9.noarch.rpm"
 			],
@@ -1953,7 +1953,7 @@
 		},
 		{
 			"name": "readline",
-			"sha256": "49945472925286ad89b0575657b43f9224777e36b442f0c88df67f0b61e26aee",
+			"integrity": "sha256-SZRUcpJShq2JsFdWV7Q/kiR3fja0QvDIjfZ/C2Hiau4=",
 			"urls": [
 				"Packages/readline-8.1-4.el9.x86_64.rpm"
 			],
@@ -1965,7 +1965,7 @@
 		},
 		{
 			"name": "sed",
-			"sha256": "a2c5d9a7f569abb5a592df1c3aaff0441bf827c9d0e2df0ab42b6c443dbc475f",
+			"integrity": "sha256-osXZp/Vpq7Wlkt8cOq/wRBv4J8nQ4t8KtCtsRD28R18=",
 			"urls": [
 				"Packages/sed-4.8-9.el9.x86_64.rpm"
 			],
@@ -1978,7 +1978,7 @@
 		},
 		{
 			"name": "setup",
-			"sha256": "42a1c5a415c44e3b55551f49595c087e2ba55f0fd9ece8056b791983601b76d2",
+			"integrity": "sha256-QqHFpBXETjtVVR9JWVwIfiulXw/Z7OgFa3kZg2AbdtI=",
 			"urls": [
 				"Packages/setup-2.13.7-10.el9.noarch.rpm"
 			],
@@ -1989,7 +1989,7 @@
 		},
 		{
 			"name": "shadow-utils",
-			"sha256": "23f14143a188cf9bf8a0315f930fbeeb0ad34c58357007a52d112c5f8b6029e0",
+			"integrity": "sha256-I/FBQ6GIz5v4oDFfkw++6wrTTFg1cAelLREsX4tgKeA=",
 			"urls": [
 				"Packages/shadow-utils-4.9-12.el9.x86_64.rpm"
 			],
@@ -2007,7 +2007,7 @@
 		},
 		{
 			"name": "systemd-libs",
-			"sha256": "a9d02a16bbc778ad3a2b46b8740fa821df065cdacd6ba8570c3301dacad79f0f",
+			"integrity": "sha256-qdAqFrvHeK06K0a4dA+oId8GXNrNa6hXDDMB2srXnw8=",
 			"urls": [
 				"Packages/systemd-libs-252-51.el9.x86_64.rpm"
 			],
@@ -2033,7 +2033,7 @@
 		},
 		{
 			"name": "tzdata",
-			"sha256": "655945e6a0e95b960a422828bc1cb3bac2232fe9b76590e35ad00069097f087a",
+			"integrity": "sha256-ZVlF5qDpW5YKQigovByzusIjL+m3ZZDjWtAAaQl/CHo=",
 			"urls": [
 				"Packages/tzdata-2025a-1.el9.noarch.rpm"
 			],
@@ -2042,7 +2042,7 @@
 		},
 		{
 			"name": "util-linux",
-			"sha256": "77f5aa59c85c1231bde7f64a7e348bb7b4675a04e385e219275abbd748037075",
+			"integrity": "sha256-d/WqWchcEjG95/ZKfjSLt7RnWgTjheIZJ1q710gDcHU=",
 			"urls": [
 				"Packages/util-linux-2.37.4-21.el9.x86_64.rpm"
 			],
@@ -2071,7 +2071,7 @@
 		},
 		{
 			"name": "util-linux-core",
-			"sha256": "1858fbea657a9edce414fd98b8260b37ef521769f06830fccc7831094ec04154",
+			"integrity": "sha256-GFj76mV6ntzkFP2YuCYLN+9SF2nwaDD8zHgxCU7AQVQ=",
 			"urls": [
 				"Packages/util-linux-core-2.37.4-21.el9.x86_64.rpm"
 			],
@@ -2090,7 +2090,7 @@
 		},
 		{
 			"name": "xz-libs",
-			"sha256": "ff3c88297d75c51a5f8e9d2d69f8ad1eaf8347e20920b4335a3e0fc53269ad28",
+			"integrity": "sha256-/zyIKX11xRpfjp0tafitHq+DR+IJILQzWj4PxTJprSg=",
 			"urls": [
 				"Packages/xz-libs-5.2.5-8.el9.x86_64.rpm"
 			],
@@ -2101,7 +2101,7 @@
 		},
 		{
 			"name": "zlib",
-			"sha256": "370951ea635bc16313f21ac2823ec815147ed1124b74865a34c54e94e4db9602",
+			"integrity": "sha256-NwlR6mNbwWMT8hrCgj7IFRR+0RJLdIZaNMVOlOTblgI=",
 			"urls": [
 				"Packages/zlib-1.2.11-41.el9.x86_64.rpm"
 			],

--- a/internal/rpm.bzl
+++ b/internal/rpm.bzl
@@ -90,7 +90,7 @@ def _rpm_impl(ctx):
             deps = ", ".join(["\"%s\"" % dep for dep in ctx.attr.dependencies]),
         ),
     )
-    return update_attrs(ctx.attr, _rpm_attrs.keys(), {"sha256": download_info.sha256})
+    return update_attrs(ctx.attr, _rpm_attrs.keys(), {"integrity": download_info.integrity})
 
 _rpm_attrs = {
     "urls": attr.string_list(),

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -225,6 +225,16 @@ type Checksum struct {
 	Pkgid string `xml:"pkgid,attr"`
 }
 
+func (c Checksum) Integrity() (string, error) {
+	if c.Type == "sha" {
+		return fmt.Sprintf("sha1-%s", c.Text), nil
+	} else if c.Type == "sha512" || c.Type == "sha256" {
+		return fmt.Sprintf("%s-%s", c.Type, c.Text), nil
+	}
+
+	return "", fmt.Errorf("Invalid integrity type: %s", c.Type)
+}
+
 type Location struct {
 	Text string `xml:",chardata"`
 	Href string `xml:"href,attr"`

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/xml"
 	"fmt"
 
@@ -225,11 +227,28 @@ type Checksum struct {
 	Pkgid string `xml:"pkgid,attr"`
 }
 
+func (c Checksum) ToBase64() (string, error) {
+	hash, err := hex.DecodeString(c.Text)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(hash), nil
+}
+
 func (c Checksum) Integrity() (string, error) {
 	if c.Type == "sha" {
-		return fmt.Sprintf("sha1-%s", c.Text), nil
+		s, err := c.ToBase64()
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("sha1-%s", s), nil
 	} else if c.Type == "sha512" || c.Type == "sha256" {
-		return fmt.Sprintf("%s-%s", c.Type, c.Text), nil
+		s, err := c.ToBase64()
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s-%s", c.Type, s), nil
 	}
 
 	return "", fmt.Errorf("Invalid integrity type: %s", c.Type)

--- a/pkg/api/bazeldnf/config.go
+++ b/pkg/api/bazeldnf/config.go
@@ -2,7 +2,7 @@ package bazeldnf
 
 type RPM struct {
 	Name         string   `json:"name"`
-	SHA256       string   `json:"sha256"`
+	Integrity    string   `json:"integrity"`
 	URLs         []string `json:"urls"`
 	Repository   string   `json:"repository"`
 	Dependencies []string `json:"dependencies"`

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -270,7 +270,7 @@ func AddTar2Files(name string, rpmtree string, buildfile *build.File, files []st
 
 func AddTree(name, configname string, buildfile *build.File, pkgs []*api.Package, arch string, public bool) {
 	transform := func(n string) string {
-		return "@"+n+"//rpm"
+		return "@" + n + "//rpm"
 	}
 	if configname != "" {
 		transform = func(n string) string {
@@ -518,12 +518,17 @@ func AddConfigRPMs(config *bazeldnf.Config, pkgs []*api.Package, arch string) er
 			URLs = append(URLs, u.String())
 		}
 
+		integrity, err := pkg.Checksum.Integrity()
+		if err != nil {
+			return fmt.Errorf("Unable to load package %s integrity: %w", pkg.String(), err)
+		}
+
 		config.RPMs = append(
 			config.RPMs,
 			&bazeldnf.RPM{
-				Name:   sanitize(pkg.String() + "." + arch),
-				SHA256: pkg.Checksum.Text,
-				URLs:   URLs,
+				Name:      sanitize(pkg.String() + "." + arch),
+				Integrity: integrity,
+				URLs:      URLs,
 			},
 		)
 	}


### PR DESCRIPTION
The underlying downloader that we use when setting up repositories should use integrity instead of SHA256 as it works for SHA512 and SHA1 hashes as well.