### PR TITLE
Calculate path to repofile correctly

### DIFF
--- a/bazeldnf/extensions.bzl
+++ b/bazeldnf/extensions.bzl
@@ -106,6 +106,8 @@ def _alias_repository_impl(repository_ctx):
 
     if repository_ctx.attr.lock_file.package:
         lock_file_path = repository_ctx.attr.lock_file.package + "/" + lock_file_path
+
+    if repository_ctx.attr.repofile.package:
         repofile = repository_ctx.attr.repofile.package + "/" + repofile
 
     repository_ctx.file(

--- a/bazeldnf/extensions.bzl
+++ b/bazeldnf/extensions.bzl
@@ -107,7 +107,7 @@ def _alias_repository_impl(repository_ctx):
     if repository_ctx.attr.lock_file.package:
         lock_file_path = repository_ctx.attr.lock_file.package + "/" + lock_file_path
 
-    if repository_ctx.attr.repofile.package:
+    if repository_ctx.attr.repofile and repository_ctx.attr.repofile.package:
         repofile = repository_ctx.attr.repofile.package + "/" + repofile
 
     repository_ctx.file(


### PR DESCRIPTION
The existence of the lockfile shouldn't control where we look for the repo file.