### PR TITLE
Add null repository rule for missing RPMs

### DIFF
--- a/bazeldnf/extensions.bzl
+++ b/bazeldnf/extensions.bzl
@@ -7,7 +7,7 @@ based on: https://github.com/bazel-contrib/rules-template/blob/0dadcb716f06f6728
 
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
-load("//internal:rpm.bzl", rpm_repository = "rpm", null_rpm_repository = "null_rpm")
+load("//internal:rpm.bzl", null_rpm_repository = "null_rpm", rpm_repository = "rpm")
 load(":repositories.bzl", "bazeldnf_register_toolchains")
 
 _DEFAULT_NAME = "bazeldnf"

--- a/bazeldnf/extensions.bzl
+++ b/bazeldnf/extensions.bzl
@@ -7,7 +7,7 @@ based on: https://github.com/bazel-contrib/rules-template/blob/0dadcb716f06f6728
 
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
-load("//internal:rpm.bzl", rpm_repository = "rpm")
+load("//internal:rpm.bzl", rpm_repository = "rpm", null_rpm_repository = "null_rpm")
 load(":repositories.bzl", "bazeldnf_register_toolchains")
 
 _DEFAULT_NAME = "bazeldnf"
@@ -159,6 +159,10 @@ _alias_repository = repository_rule(
     },
 )
 
+def _to_rpm_repo_name(prefix, rpm_name):
+    name = rpm_name.replace("+", "plus")
+    return "{}{}".format(prefix, name)
+
 def _handle_lock_file(config, module_ctx, registered_rpms = {}):
     if not config.lock_file:
         fail("No lock file provided for %s" % config.name)
@@ -200,8 +204,7 @@ def _handle_lock_file(config, module_ctx, registered_rpms = {}):
                 fail("invalid entry in %s for %s" % (config.lock_file, rpm_name))
             rpm_name = urls[0].rsplit("/", 1)[-1]
 
-        name = rpm_name.replace("+", "plus")
-        name = "{}{}".format(config.rpm_repository_prefix, name)
+        name = _to_rpm_repo_name(config.rpm_repository_prefix, rpm_name)
         if name in registered_rpms:
             continue
         registered_rpms[name] = 1
@@ -217,6 +220,16 @@ def _handle_lock_file(config, module_ctx, registered_rpms = {}):
             urls = urls,
             **rpm
         )
+
+    # if there's targets without matching RPMs we need to create a null target
+    # so that consumers have something consistent that they can depend on
+    for target in lock_file_json.get("targets", []):
+        name = _to_rpm_repo_name(config.rpm_repository_prefix, target)
+        if name in registered_rpms:
+            continue
+
+        null_rpm_repository(name = name)
+        registered_rpms[name] = 1
 
     repository_args["rpms"] = ["@@%s//rpm" % x for x in registered_rpms.keys()]
 

--- a/internal/rpm.bzl
+++ b/internal/rpm.bzl
@@ -107,7 +107,7 @@ rpm = repository_rule(
     attrs = _rpm_attrs,
 )
 
-def _null_rpm_rule_impl(ctx):
+def _null_rpm_rule_impl(_):
     return [
         RpmInfo(
             file = "",

--- a/internal/rpm.bzl
+++ b/internal/rpm.bzl
@@ -106,3 +106,35 @@ rpm = repository_rule(
     implementation = _rpm_impl,
     attrs = _rpm_attrs,
 )
+
+def _null_rpm_rule_impl(ctx):
+    return [
+        RpmInfo(
+            file = "",
+            deps = depset(),
+        ),
+        DefaultInfo(files = depset()),
+    ]
+
+null_rpm_rule = rule(
+    implementation = _null_rpm_rule_impl,
+)
+
+_NULL_FILE_BUILD = """
+load("@bazeldnf//internal:rpm.bzl", "null_rpm_rule")
+package(default_visibility = ["//visibility:public"])
+null_rpm_rule(
+    name = "rpm",
+)
+"""
+
+def _null_rpm_impl(ctx):
+    ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))
+    ctx.file(
+        "rpm/BUILD",
+        _NULL_FILE_BUILD,
+    )
+
+null_rpm = repository_rule(
+    implementation = _null_rpm_impl,
+)


### PR DESCRIPTION
Depending on the consumption model, users may need to have a stable set of targets and repository rules to depend on even if the underlying RPMs are missing.  This change is the other side of allowing some of our RPM targets to be missing: if they are missing we can generate dummy repository rules so that we get stable deps.