### PR TITLE
Watch the lock file

### DIFF
--- a/bazeldnf/extensions.bzl
+++ b/bazeldnf/extensions.bzl
@@ -177,6 +177,8 @@ def _handle_lock_file(config, module_ctx, registered_rpms = {}):
         "nobest": config.nobest,
     }
 
+    module_ctx.watch(config.lock_file)
+
     if config.cache_dir:
         repository_args["cache_dir"] = config.cache_dir
 


### PR DESCRIPTION
If we don't watch the lock file and we update it (eg: with bazel run) it'll fail to get noticed.