### PR TITLE
rpm: stop calling things downloaded

### DIFF
--- a/internal/rpm.bzl
+++ b/internal/rpm.bzl
@@ -73,7 +73,7 @@ rpm_rule(
 
 def _rpm_impl(ctx):
     if ctx.attr.urls:
-        downloaded_file_path = "downloaded"
+        downloaded_file_path = ctx.attr.urls[0].split("/")[-1]
         download_info = ctx.download(
             url = ctx.attr.urls,
             output = "rpm/" + downloaded_file_path,

--- a/pkg/rpm/BUILD.bazel
+++ b/pkg/rpm/BUILD.bazel
@@ -26,9 +26,15 @@ go_test(
     ],
     data = [
         "@bazeldnf_internal_abseil-cpp-devel//rpm",
+        "@bazeldnf_internal_libvirt-devel//rpm",
         "@bazeldnf_internal_libvirt-libs//rpm",
     ],
     embed = [":rpm"],
+    env = {
+        "CPP_DEVEL": "$(rlocationpath @bazeldnf_internal_abseil-cpp-devel//rpm)",
+        "LIBVIRT_DEVEL": "$(rlocationpath @bazeldnf_internal_libvirt-devel//rpm)",
+        "LIBVIRT_LIBS": "$(rlocationpath @bazeldnf_internal_libvirt-libs//rpm)",
+    },
     deps = [
         "//pkg/api",
         "@com_github_onsi_gomega//:gomega",

--- a/pkg/rpm/tar_test.go
+++ b/pkg/rpm/tar_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestRPMToTar(t *testing.T) {
-	libvirtLibsRpm, err := runfiles.Rlocation("bazeldnf_internal_libvirt-libs/rpm/downloaded")
+	libvirtLibsRpm, err := runfiles.Rlocation(os.Getenv("LIBVIRT_LIBS"))
 	if err != nil {
 		panic(err)
 	}
@@ -89,12 +89,12 @@ func TestRPMToTar(t *testing.T) {
 }
 
 func TestTar2Files(t *testing.T) {
-	abseilCppDevelRpm, err := runfiles.Rlocation("bazeldnf_internal_abseil-cpp-devel/rpm/downloaded")
+	abseilCppDevelRpm, err := runfiles.Rlocation(os.Getenv("CPP_DEVEL"))
 	if err != nil {
 		panic(err)
 	}
 
-	libvirtLibsRpm, err := runfiles.Rlocation("bazeldnf_internal_libvirt-libs/rpm/downloaded")
+	libvirtLibsRpm, err := runfiles.Rlocation(os.Getenv("LIBVIRT_LIBS"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Stop calling the artifact downloaded from the internet downloaded, instead call it by it's URL basename, this is more human friendly when debugging what's going on, also makes testing easier