### PR TITLE
Several small non related fixes

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@gazelle//:def.bzl", "gazelle", "gazelle_binary")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//bazeldnf:defs.bzl", "bazeldnf", "rpmtree", "tar2files")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -100,3 +100,5 @@ register_toolchains(
     "@toolchains_protoc_hub//:all",
     dev_dependency = True,
 )
+
+bazel_dep(name = "rules_cc", version = "0.1.1", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@
 module(
     name = "bazeldnf",
     version = "v0.0.0",
-    bazel_compatibility = [">=6.0.0"],
+    bazel_compatibility = [">=7.0.0"],
     compatibility_level = 0,
 )
 

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ e2e-workspace:
 	@for version in 6.x 7.x; do \
 		( \
 			cd e2e/bazel-workspace && \
-			echo "Testing $$version" > /dev/stderr && \
+			echo "Testing $$version in workspace mode" > /dev/stderr && \
 			USE_BAZEL_VERSION=$$version bazelisk --batch build //...\
 		) \
 	done
 
 e2e-bzlmod:
-	@for version in 6.x 7.x; do \
+	@for version in 7.x 8.x; do \
 		( \
 			cd e2e/bazel-bzlmod && \
 			echo "Testing $$version with bzlmod" > /dev/stderr && \
@@ -34,7 +34,7 @@ e2e-bzlmod:
 	done
 
 e2e-bazel-bzlmod-lock-file:
-	@for version in 6.x 7.x; do \
+	@for version in 7.x 8.x; do \
 		( \
 			cd e2e/bazel-bzlmod-lock-file && \
 			echo "Testing $$version with bzlmod with lock file" > /dev/stderr && \
@@ -42,15 +42,40 @@ e2e-bazel-bzlmod-lock-file:
 		) \
 	done
 
-e2e-bzlmod-build-toolchain-7.x:
-	( \
-		cd e2e/bazel-bzlmod-toolchain-from-source && \
-		USE_BAZEL_VERSION=7.x bazelisk --batch build //... --incompatible_enable_proto_toolchain_resolution \
-	)
+e2e-bzlmod-build-toolchain:
+	@for version in 7.x 8.x; do \
+		( \
+			cd e2e/bazel-bzlmod-toolchain-from-source && \
+			echo "Testing $$version with bzlmod build toolchain" > /dev/stderr && \
+			USE_BAZEL_VERSION=$$version bazelisk --batch build //... --incompatible_enable_proto_toolchain_resolution \
+		) \
+	done
 
-e2e-bzlmod-build-toolchain: e2e-bzlmod-build-toolchain-7.x
+e2e-bazel-bzlmod-lock-file-from-args:
+	@for version in 7.x 8.x; do \
+		( \
+			cd e2e/bazel-bzlmod-lock-file-from-args && \
+			echo "Testing $$version bzlmod lock file from args" > /dev/stderr && \
+			USE_BAZEL_VERSION=$$version bazelisk --batch build //... --incompatible_enable_proto_toolchain_resolution \
+		) \
+	done
 
-e2e: e2e-workspace e2e-bzlmod e2e-bzlmod-build-toolchain
+e2e-bzlmod-toolchain-circular-dependencies:
+	@for version in 7.x 8.x; do \
+		( \
+			cd e2e/bzlmod-toolchain-circular-dependencies && \
+			echo "Testing $$version bzlmod lock file from args" > /dev/stderr && \
+			USE_BAZEL_VERSION=$$version bazelisk --batch build //... --incompatible_enable_proto_toolchain_resolution \
+		) \
+	done
+
+
+e2e: e2e-workspace \
+	e2e-bzlmod \
+	e2e-bzlmod-build-toolchain \
+	e2e-bazel-bzlmod-lock-file \
+	e2e-bazel-bzlmod-lock-file-from-args \
+	e2e-bzlmod-toolchain-circular-dependencies
 
 fmt: gofmt buildifier
 

--- a/e2e/bazel-bzlmod-lock-file/BUILD.bazel
+++ b/e2e/bazel-bzlmod-lock-file/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazeldnf//bazeldnf:defs.bzl", "bazeldnf", "rpmtree", "tar2files")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 bazeldnf(

--- a/e2e/bazel-bzlmod-lock-file/MODULE.bazel
+++ b/e2e/bazel-bzlmod-lock-file/MODULE.bazel
@@ -47,3 +47,5 @@ use_repo(
     "bazeldnf-others",
     "bazeldnf-rpms",
 )
+
+bazel_dep(name = "rules_cc", version = "0.1.1", dev_dependency = True)

--- a/e2e/bazel-bzlmod-toolchain-from-source/BUILD.bazel
+++ b/e2e/bazel-bzlmod-toolchain-from-source/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazeldnf//bazeldnf:defs.bzl", "bazeldnf", "rpmtree", "tar2files")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 bazeldnf(

--- a/e2e/bazel-bzlmod-toolchain-from-source/MODULE.bazel
+++ b/e2e/bazel-bzlmod-toolchain-from-source/MODULE.bazel
@@ -62,3 +62,5 @@ use_repo(
     "libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
     "libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
 )
+
+bazel_dep(name = "rules_cc", version = "0.1.1", dev_dependency = True)

--- a/e2e/bazel-bzlmod/BUILD.bazel
+++ b/e2e/bazel-bzlmod/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazeldnf//bazeldnf:defs.bzl", "bazeldnf", "rpmtree", "tar2files")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 bazeldnf(

--- a/e2e/bazel-bzlmod/MODULE.bazel
+++ b/e2e/bazel-bzlmod/MODULE.bazel
@@ -30,3 +30,5 @@ use_repo(
     "libvirt-devel-11.0.0-1.fc42.x86_64.rpm",
     "libvirt-libs-11.0.0-1.fc42.x86_64.rpm",
 )
+
+bazel_dep(name = "rules_cc", version = "0.1.1", dev_dependency = True)

--- a/e2e/bazel-workspace/BUILD.bazel
+++ b/e2e/bazel-workspace/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazeldnf//bazeldnf:defs.bzl", "bazeldnf", "rpmtree", "tar2files")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 bazeldnf(

--- a/e2e/bazel-workspace/WORKSPACE
+++ b/e2e/bazel-workspace/WORKSPACE
@@ -58,3 +58,21 @@ http_archive(
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
+
+http_archive(
+    name = "rules_cc",
+    sha256 = "712d77868b3152dd618c4d64faaddefcc5965f90f5de6e6dd1d5ddcd0be82d42",
+    strip_prefix = "rules_cc-0.1.1",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.1/rules_cc-0.1.1.tar.gz"],
+)
+
+load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
+
+rules_cc_dependencies()
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "da288bf1daa6c04d03a9051781caa52aceb9163586bff9aa6cfb12f69b9395aa",
+    strip_prefix = "protobuf-27.0",
+    url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",
+)

--- a/internal/rpm.bzl
+++ b/internal/rpm.bzl
@@ -74,11 +74,15 @@ rpm_rule(
 def _rpm_impl(ctx):
     if ctx.attr.urls:
         downloaded_file_path = "downloaded"
-        download_info = ctx.download(
+        args = {}
+        if ctx.attr.integrity:
+            args["integrity"] = ctx.attr.integrity
+        if ctx.attr.sha256:
+            args["sha256"] = ctx.attr.sha256
+        ctx.download(
             url = ctx.attr.urls,
             output = "rpm/" + downloaded_file_path,
-            sha256 = ctx.attr.sha256,
-            integrity = ctx.attr.integrity,
+            **args
         )
     else:
         fail("urls must be specified")
@@ -90,7 +94,7 @@ def _rpm_impl(ctx):
             deps = ", ".join(["\"%s\"" % dep for dep in ctx.attr.dependencies]),
         ),
     )
-    return update_attrs(ctx.attr, _rpm_attrs.keys(), {"integrity": download_info.integrity})
+    return update_attrs(ctx.attr, _rpm_attrs.keys(), args)
 
 _rpm_attrs = {
     "urls": attr.string_list(),


### PR DESCRIPTION
* rpm_repository is giving annoying warnings in sha256 mode
* watch files in repository_ctx requires bazel 7.x, so let's restrict bzlmod to at least this version
* add missing tests in Makefile wrapper
* add missing import of rules_cc
