### PR TITLE
Add auth_patterns support to RPM rule

### DIFF
--- a/cmd/lockfile.go
+++ b/cmd/lockfile.go
@@ -10,9 +10,9 @@ import (
 )
 
 type lockfileOpts struct {
-	repofiles      []string
-	configname     string
-	lockfile       string
+	repofiles  []string
+	configname string
+	lockfile   string
 }
 
 var lockfileopts = lockfileOpts{}
@@ -22,7 +22,7 @@ func NewLockFileCmd() *cobra.Command {
 	lockfileCmd := &cobra.Command{
 		Use:   "lockfile",
 		Short: "Manage bazeldnf lock file",
-		Long: `Keep the bazeldnf lock file up to date using a set of dependencies`,
+		Long:  `Keep the bazeldnf lock file up to date using a set of dependencies`,
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, required []string) error {
 			repos, err := repo.LoadRepoFiles(lockfileopts.repofiles)

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -10,7 +10,7 @@ import (
 )
 
 type resolveOpts struct {
-	repofiles        []string
+	repofiles []string
 }
 
 var resolveopts = resolveOpts{}

--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -14,14 +14,14 @@ import (
 )
 
 type rpmtreeOpts struct {
-	repofiles        []string
-	workspace        string
-	toMacro          string
-	buildfile        string
-	configname       string
-	lockfile         string
-	name             string
-	public           bool
+	repofiles  []string
+	workspace  string
+	toMacro    string
+	buildfile  string
+	configname string
+	lockfile   string
+	name       string
+	public     bool
 }
 
 var rpmtreeopts = rpmtreeOpts{}

--- a/pkg/reducer/helper_test.go
+++ b/pkg/reducer/helper_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/rmohr/bazeldnf/pkg/api/bazeldnf"
 )
 
-func withRepository(packages []api.Package) []api.Package{
+func withRepository(packages []api.Package) []api.Package {
 	r := []api.Package{}
 	for _, p := range packages {
 		p.Repository = &bazeldnf.Repository{}

--- a/pkg/sat/sat_test.go
+++ b/pkg/sat/sat_test.go
@@ -1354,9 +1354,9 @@ func TestNewResolver(t *testing.T) {
 			"testa",
 		},
 			ignoreRegex: []string{"testb.*"},
-			install: []string{"testa-0:1", "testc-0:1"},
-			exclude: []string{},
-			solvable: true,
+			install:     []string{"testa-0:1", "testc-0:1"},
+			exclude:     []string{},
+			solvable:    true,
 		},
 		{name: "only allow package", packages: []*api.Package{
 			newPkg("testa", "1", []string{}, []string{"b", "c"}, []string{}),
@@ -1366,9 +1366,9 @@ func TestNewResolver(t *testing.T) {
 			"testa",
 		},
 			allowRegex: []string{"testa.*"},
-			install: []string{"testa-0:1"},
-			exclude: []string{},
-			solvable: true,
+			install:    []string{"testa-0:1"},
+			exclude:    []string{},
+			solvable:   true,
 		},
 		// TODO: Add test cases.
 	}


### PR DESCRIPTION
Sometimes RPM rules are on non-public locations. Add .netrc support to RPM rules.


RPM rules now supports the usual pattern:

```
rpm(
    ...,
    auth_patterns = {
        "storage.cloudprovider.com": "Bearer <password>"
    }
)
```