### PR TITLE
Fix issues on bazeldnf and xattr rule invocations

### DIFF
--- a/internal/bazeldnf.bzl
+++ b/internal/bazeldnf.bzl
@@ -4,7 +4,7 @@ load("@bazel_skylib//lib:shell.bzl", "shell")
 load("//bazeldnf:toolchain.bzl", "BAZELDNF_TOOLCHAIN")
 
 def _bazeldnf_impl(ctx):
-    transitive_dependencies = []
+    transitive_dependencies = depset([])
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     args = []
     if ctx.attr.command:
@@ -15,7 +15,7 @@ def _bazeldnf_impl(ctx):
         args.extend(["--rpmtree", ctx.attr.rpmtree])
     if ctx.file.tar:
         args.extend(["--input", ctx.file.tar.path])
-        transitive_dependencies.extend(ctx.attr.tar.files)
+        transitive_dependencies = ctx.attr.tar.files
     args.extend(ctx.attr.libs)
 
     toolchain = ctx.toolchains[BAZELDNF_TOOLCHAIN]
@@ -32,7 +32,7 @@ def _bazeldnf_impl(ctx):
     )
     runfiles = ctx.runfiles(
         files = [toolchain._tool],
-        transitive_files = depset([], transitive = transitive_dependencies),
+        transitive_files = depset([], transitive = [transitive_dependencies]),
     )
     return [DefaultInfo(
         files = depset([out_file]),

--- a/internal/xattrs.bzl
+++ b/internal/xattrs.bzl
@@ -23,7 +23,7 @@ def _xattrs_impl(ctx):
     if ctx.attr.capabilities:
         capabilities = []
         for k, v in ctx.attr.capabilities.items():
-            capabilities.append([k + "=" + ":".join(v)])
+            capabilities.append(k + "=" + ":".join(v))
         args += ["--capabilities", ",".join(capabilities)]
 
     if ctx.attr.selinux_labels:


### PR DESCRIPTION
First, if bazeldnf is invoked via bazel itself, transitive dependencies are treated as iterables, which is long deprecated and which can fail on newer versions with:

```
Error in extend: type 'depset' is not iterable
```

Second, the `xattr` rule was not properly constructing the arguments list which seems to only now be visible:

```
		args += ["--capabilities", ",".join(capabilities)]
Error in join: expected string for sequence element 0, got 'list'
```