### PR TITLE
Ensure that extra symlinks don't overlap with RPM included symlinks

### DIFF
--- a/pkg/rpm/tar.go
+++ b/pkg/rpm/tar.go
@@ -25,6 +25,10 @@ func NewCollector() *Collector {
 	}
 }
 
+func (c *Collector) AddPath(path string) {
+	c.createdPaths[path] = struct{}{}
+}
+
 func (c *Collector) RPMToTar(rpmReader io.Reader, tarWriter *tar.Writer, noSymlinksAndDirs bool, capabilities map[string][]string, selinuxLabels map[string]string) error {
 	rpm, err := rpmutils.ReadRpm(rpmReader)
 	if err != nil {


### PR DESCRIPTION
In order to create valid oci layers, we need to also consider symlinks which are extra added to an rpmtree to avoid duplicate reation, in case the RPM contains the link already and we just seek to override it.

Still need to create a test.

Fixes: #88