### PR TITLE
Make xattr more flexible on different tar formats

### DIFF
--- a/cmd/xattr.go
+++ b/cmd/xattr.go
@@ -3,10 +3,12 @@ package main
 import (
 	"archive/tar"
 	"os"
+	"path/filepath"
 	"strings"
 
-	"github.com/rmohr/bazeldnf/pkg/xattr"
 	"github.com/spf13/cobra"
+
+	"github.com/rmohr/bazeldnf/pkg/xattr"
 )
 
 type xattrOpts struct {
@@ -29,12 +31,12 @@ func NewXATTRCmd() *cobra.Command {
 			for file, caps := range xattropts.capabilities {
 				split := strings.Split(caps, ":")
 				if len(split) > 0 {
-					capabilityMap["./"+strings.TrimPrefix(file, "/")] = split
+					capabilityMap[filepath.Clean(strings.TrimPrefix(file, "/"))] = split
 				}
 			}
 			labelMap := map[string]string{}
 			for file, label := range xattropts.selinuxLabels {
-				labelMap["./"+strings.TrimPrefix(file, "/")] = label
+				labelMap[filepath.Clean(strings.TrimPrefix(file, "/"))] = label
 			}
 
 			streamInput := os.Stdin

--- a/pkg/xattr/xattr.go
+++ b/pkg/xattr/xattr.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 )
 
 const (
@@ -71,13 +73,14 @@ func enrichEntry(entry *tar.Header, capabilties map[string][]string, labels map[
 	if entry.PAXRecords == nil {
 		entry.PAXRecords = map[string]string{}
 	}
+	fileName := filepath.Clean(strings.TrimPrefix(entry.Name, "/"))
 
-	if caps, exists := capabilties[entry.Name]; exists {
+	if caps, exists := capabilties[fileName]; exists {
 		if err := AddCapabilities(entry.PAXRecords, caps); err != nil {
 			return err
 		}
 	}
-	if l, exists := labels[entry.Name]; exists {
+	if l, exists := labels[fileName]; exists {
 		if err := SetSELinuxLabel(entry.PAXRecords, l); err != nil {
 			return err
 		}


### PR DESCRIPTION
Newer bazel versions tar archives do not always start with `./` anymore but have just no prefix. Ensure that xattr can deal with paths starting with `./` but also without a prefix.