### PR TITLE
Support params file for tar2files command

### DIFF
--- a/internal/rpmtree.bzl
+++ b/internal/rpmtree.bzl
@@ -72,7 +72,8 @@ def _expand_path(files):
 
 def _tar2files_impl(ctx):
     args = ctx.actions.args()
-
+    args.set_param_file_format("multiline")
+    args.use_param_file("@%s")
     args.add_all(["tar2files", "--file-prefix", ctx.attr.prefix, "--input", ctx.files.tar[0]])
     args.add_all([ctx.outputs.out], map_each = _expand_path)
 


### PR DESCRIPTION
On some platforms, the `tar2files` operation fails with the error "error=7, Argument list too long" when extracting RPMs with a large number of files (e.g., Boost's ~14K files) by passing them directly as command-line arguments. To circumvent this, we supply a single text file containing the list of files to be extracted. This optimization is applied only when the RPM contains more than 100 files, minimizing overhead for smaller RPMs.

Change-Id: I5ae84078ccddd7e948d0e5a9faa2583ca7217cf5