### PR TITLE
Allow tar2files to use an empty prefix

### DIFF
--- a/cmd/tar2files.go
+++ b/cmd/tar2files.go
@@ -10,8 +10,9 @@ import (
 )
 
 type tar2filesOpts struct {
-	filePrefix string
-	tarFile    string
+	filePrefix  string
+	stripPrefix string
+	tarFile     string
 }
 
 var tar2filesopts = tar2filesOpts{}
@@ -28,12 +29,12 @@ func NewTar2FilesCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("could not open rpm at %s: %v", tar2filesopts.tarFile, err)
 				}
-				err = rpm.PrefixFilter(tar2filesopts.filePrefix, tar.NewReader(tarStream), args)
+				err = rpm.PrefixFilter(tar2filesopts.filePrefix, tar2filesopts.stripPrefix, tar.NewReader(tarStream), args)
 				if err != nil {
 					return fmt.Errorf("could not convert rpm at %s: %v", tar2filesopts.tarFile, err)
 				}
 			} else {
-				err = rpm.PrefixFilter(tar2filesopts.filePrefix, tar.NewReader(tarStream), args)
+				err = rpm.PrefixFilter(tar2filesopts.filePrefix, tar2filesopts.stripPrefix, tar.NewReader(tarStream), args)
 				if err != nil {
 					return fmt.Errorf("could not convert rpm : %v", err)
 				}
@@ -44,5 +45,6 @@ func NewTar2FilesCmd() *cobra.Command {
 
 	tar2filesCmd.Flags().StringVarP(&tar2filesopts.tarFile, "input", "i", "", "location from where to read the tar file (defaults to stdin)")
 	tar2filesCmd.Flags().StringVar(&tar2filesopts.filePrefix, "file-prefix", "", "only keep files with this directory prefix")
+	tar2filesCmd.Flags().StringVar(&tar2filesopts.stripPrefix, "strip-prefix", "", "strip prefix from provided files")
 	return tar2filesCmd
 }

--- a/internal/rpmtree.bzl
+++ b/internal/rpmtree.bzl
@@ -73,7 +73,14 @@ def _expand_path(files):
 def _tar2files_impl(ctx):
     args = ctx.actions.args()
 
-    args.add_all(["tar2files", "--file-prefix", ctx.attr.prefix, "--input", ctx.files.tar[0]])
+    strip_prefix = ctx.bin_dir.path + "/" + ctx.label.package + "/" + ctx.label.name
+
+    args.add_all([
+        "tar2files",
+        "--file-prefix", ctx.attr.prefix,
+        "--strip-prefix", strip_prefix,
+        "--input", ctx.files.tar[0],
+    ])
     args.add_all([ctx.outputs.out], map_each = _expand_path)
 
     ctx.actions.run(

--- a/pkg/rpm/tar_test.go
+++ b/pkg/rpm/tar_test.go
@@ -193,7 +193,7 @@ func TestTar2Files(t *testing.T) {
 				files = append(files, filepath.Join(tmpdir, file))
 			}
 
-			err = PrefixFilter(tt.prefix, tar.NewReader(pipeReader), files)
+			err = PrefixFilter(tt.prefix, tmpdir, tar.NewReader(pipeReader), files)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			discoveredHeaders, err := collectFileInfo(tmpdir)


### PR DESCRIPTION
tar2files currently requires that you break down the extraction process into multiple groups of files based on prefix but it does not allow you to have a single prefix for everything (ie: prefix="").  When dealing with dependencies that traverse prefix-groups, this becomes a pain to pipe into other bazel rules.

This change performs the necessary fixes to allow us to be able to do this instead of requiring everything to be broken down by prefix.