### PR TITLE
Do proper path join for strip_prefix

### DIFF
--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -22,7 +22,10 @@ bzl_library(
     name = "rpmtree",
     srcs = ["rpmtree.bzl"],
     visibility = ["//:__subpackages__"],
-    deps = ["//bazeldnf:toolchain"],
+    deps = [
+        "//bazeldnf:toolchain",
+        "@bazel_skylib//lib:paths",
+    ],
 )
 
 bzl_library(

--- a/internal/rpmtree.bzl
+++ b/internal/rpmtree.bzl
@@ -19,6 +19,7 @@ rpm files into either a .tar or extract files from that tar to
 make available to bazel
 """
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//bazeldnf:toolchain.bzl", "BAZELDNF_TOOLCHAIN")
 load("//internal:rpm.bzl", "RpmInfo")
 
@@ -72,7 +73,11 @@ def _expand_path(files):
 
 def _tar2files_impl(ctx):
     args = ctx.actions.args()
-    strip_prefix = ctx.bin_dir.path + ctx.label.package + "/" + ctx.label.name
+    strip_prefix = paths.join(
+        ctx.bin_dir.path,
+        ctx.label.package,
+        ctx.label.name,
+    )
 
     args.set_param_file_format("multiline")
     args.use_param_file("@%s")


### PR DESCRIPTION
In some cases there's a `/` at the end of `bin_dir.path` and in some cases there isn't.  Using `paths.join()` should deal properly with both cases.

note: this deals with a breakage caused by PR #140 