### PR TITLE
Break down the SAT solver into separate loading and resolving steps

### DIFF
--- a/cmd/resolve_helper.go
+++ b/cmd/resolve_helper.go
@@ -33,17 +33,17 @@ func resolve(repos *bazeldnf.Repositories, required []string) ([]*api.Package, [
 
 	solver := sat.NewResolver()
 	logrus.Info("Loading involved packages into the resolver.")
-	err = solver.LoadInvolvedPackages(involved, resolvehelperopts.forceIgnoreRegex, resolvehelperopts.onlyAllowRegex, resolvehelperopts.nobest)
+	model, err := solver.LoadInvolvedPackages(involved, resolvehelperopts.forceIgnoreRegex, resolvehelperopts.onlyAllowRegex, resolvehelperopts.nobest)
 	if err != nil {
 		return nil, nil, err
 	}
 	logrus.Info("Adding required packages to the resolver.")
-	err = solver.ConstructRequirements(matched)
+	err = solver.ConstructRequirements(model, matched)
 	if err != nil {
 		return nil, nil, err
 	}
 	logrus.Info("Solving.")
-	install, _, forceIgnored, err := solver.Resolve()
+	install, _, forceIgnored, err := solver.Resolve(model)
 	return install, forceIgnored, err
 }
 

--- a/cmd/resolve_helper.go
+++ b/cmd/resolve_helper.go
@@ -33,12 +33,7 @@ func resolve(repos *bazeldnf.Repositories, required []string) ([]*api.Package, [
 
 	solver := sat.NewResolver()
 	logrus.Info("Loading involved packages into the resolver.")
-	model, err := solver.LoadInvolvedPackages(involved, resolvehelperopts.forceIgnoreRegex, resolvehelperopts.onlyAllowRegex, resolvehelperopts.nobest)
-	if err != nil {
-		return nil, nil, err
-	}
-	logrus.Info("Adding required packages to the resolver.")
-	err = solver.ConstructRequirements(model, matched)
+	model, err := solver.LoadInvolvedPackages(involved, matched, resolvehelperopts.forceIgnoreRegex, resolvehelperopts.onlyAllowRegex, resolvehelperopts.nobest)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/resolve_helper.go
+++ b/cmd/resolve_helper.go
@@ -40,8 +40,7 @@ func resolve(repos *bazeldnf.Repositories, required []string) ([]*api.Package, [
 	}
 
 	logrus.Info("Solving.")
-	solver := sat.NewResolver()
-	install, _, forceIgnored, err := solver.Resolve(model)
+	install, _, forceIgnored, err := sat.Resolve(model)
 	return install, forceIgnored, err
 }
 

--- a/cmd/resolve_helper.go
+++ b/cmd/resolve_helper.go
@@ -31,13 +31,16 @@ func resolve(repos *bazeldnf.Repositories, required []string) ([]*api.Package, [
 		return nil, nil, nil
 	}
 
-	solver := sat.NewResolver()
+	loader := sat.NewLoader()
+
 	logrus.Info("Loading involved packages into the resolver.")
-	model, err := solver.LoadInvolvedPackages(involved, matched, resolvehelperopts.forceIgnoreRegex, resolvehelperopts.onlyAllowRegex, resolvehelperopts.nobest)
+	model, err := loader.Load(involved, matched, resolvehelperopts.forceIgnoreRegex, resolvehelperopts.onlyAllowRegex, resolvehelperopts.nobest)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	logrus.Info("Solving.")
+	solver := sat.NewResolver()
 	install, _, forceIgnored, err := solver.Resolve(model)
 	return install, forceIgnored, err
 }

--- a/pkg/sat/sat.go
+++ b/pkg/sat/sat.go
@@ -402,13 +402,7 @@ func (loader *Loader) resolveNewest(pkgName string) (*Var, error) {
 	return newest, nil
 }
 
-type Resolver struct{}
-
-func NewResolver() *Resolver {
-	return &Resolver{}
-}
-
-func (res *Resolver) Resolve(model *Model) (install []*api.Package, excluded []*api.Package, forceIgnoredWithDependencies []*api.Package, err error) {
+func Resolve(model *Model) (install []*api.Package, excluded []*api.Package, forceIgnoredWithDependencies []*api.Package, err error) {
 	logrus.WithField("bf", model.Ands()).Debug("Formula to solve")
 
 	satReader, satWriter := io.Pipe()

--- a/pkg/sat/sat_determinsitic_test.go
+++ b/pkg/sat/sat_determinsitic_test.go
@@ -65,11 +65,11 @@ func TestDeterministicOutput(t *testing.T) {
 			for i, _ := range repo.Packages {
 				packages = append(packages, &repo.Packages[i])
 			}
-			err = resolver.LoadInvolvedPackages(packages, nil, nil, false)
+			model, err := resolver.LoadInvolvedPackages(packages, nil, nil, false)
 			g.Expect(err).ToNot(HaveOccurred())
-			err = resolver.ConstructRequirements(tt.requires)
+			err = resolver.ConstructRequirements(model, tt.requires)
 			g.Expect(err).ToNot(HaveOccurred())
-			install, _, _, err := resolver.Resolve()
+			install, _, _, err := resolver.Resolve(model)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(installToString(install)).To(ConsistOf(tt.installs))
 		})

--- a/pkg/sat/sat_determinsitic_test.go
+++ b/pkg/sat/sat_determinsitic_test.go
@@ -69,8 +69,7 @@ func TestDeterministicOutput(t *testing.T) {
 			model, err := loader.Load(packages, tt.requires, nil, nil, false)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			resolver := NewResolver()
-			install, _, _, err := resolver.Resolve(model)
+			install, _, _, err := Resolve(model)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(installToString(install)).To(ConsistOf(tt.installs))
 		})

--- a/pkg/sat/sat_determinsitic_test.go
+++ b/pkg/sat/sat_determinsitic_test.go
@@ -65,9 +65,7 @@ func TestDeterministicOutput(t *testing.T) {
 			for i, _ := range repo.Packages {
 				packages = append(packages, &repo.Packages[i])
 			}
-			model, err := resolver.LoadInvolvedPackages(packages, nil, nil, false)
-			g.Expect(err).ToNot(HaveOccurred())
-			err = resolver.ConstructRequirements(model, tt.requires)
+			model, err := resolver.LoadInvolvedPackages(packages, tt.requires, nil, nil, false)
 			g.Expect(err).ToNot(HaveOccurred())
 			install, _, _, err := resolver.Resolve(model)
 			g.Expect(err).ToNot(HaveOccurred())

--- a/pkg/sat/sat_determinsitic_test.go
+++ b/pkg/sat/sat_determinsitic_test.go
@@ -60,13 +60,16 @@ func TestDeterministicOutput(t *testing.T) {
 			err = xml.NewDecoder(f).Decode(repo)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			resolver := NewResolver()
 			packages := []*api.Package{}
 			for i, _ := range repo.Packages {
 				packages = append(packages, &repo.Packages[i])
 			}
-			model, err := resolver.LoadInvolvedPackages(packages, tt.requires, nil, nil, false)
+
+			loader := NewLoader()
+			model, err := loader.Load(packages, tt.requires, nil, nil, false)
 			g.Expect(err).ToNot(HaveOccurred())
+
+			resolver := NewResolver()
 			install, _, _, err := resolver.Resolve(model)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(installToString(install)).To(ConsistOf(tt.installs))

--- a/pkg/sat/sat_test.go
+++ b/pkg/sat/sat_test.go
@@ -27,9 +27,7 @@ func TestRecursive(t *testing.T) {
 			for i, _ := range repo.Packages {
 				packages = append(packages, &repo.Packages[i])
 			}
-			model, err := resolver.LoadInvolvedPackages(packages, nil, nil, false)
-			g.Expect(err).ToNot(HaveOccurred())
-			err = resolver.ConstructRequirements(model, []string{pkg.Name})
+			model, err := resolver.LoadInvolvedPackages(packages, []string{pkg.Name}, nil, nil, false)
 			g.Expect(err).ToNot(HaveOccurred())
 			_, _, _, err = resolver.Resolve(model)
 			if err != nil {
@@ -1229,9 +1227,7 @@ func Test(t *testing.T) {
 			for i, _ := range repo.Packages {
 				packages = append(packages, &repo.Packages[i])
 			}
-			model, err := resolver.LoadInvolvedPackages(packages, nil, nil, tt.nobest)
-			g.Expect(err).ToNot(HaveOccurred())
-			err = resolver.ConstructRequirements(model, tt.requires)
+			model, err := resolver.LoadInvolvedPackages(packages, tt.requires, nil, nil, tt.nobest)
 			g.Expect(err).ToNot(HaveOccurred())
 			install, _, _, err := resolver.Resolve(model)
 			g.Expect(err).ToNot(HaveOccurred())
@@ -1385,13 +1381,8 @@ func TestNewResolver(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			resolver := NewResolver()
-			model, err := resolver.LoadInvolvedPackages(tt.packages, tt.ignoreRegex, tt.allowRegex, tt.nobest)
+			model, err := resolver.LoadInvolvedPackages(tt.packages, tt.requires, tt.ignoreRegex, tt.allowRegex, tt.nobest)
 			if err != nil {
-				t.Fail()
-			}
-			err = resolver.ConstructRequirements(model, tt.requires)
-			if err != nil {
-				fmt.Println(err)
 				t.Fail()
 			}
 			install, exclude, _, err := resolver.Resolve(model)

--- a/pkg/sat/sat_test.go
+++ b/pkg/sat/sat_test.go
@@ -27,11 +27,11 @@ func TestRecursive(t *testing.T) {
 			for i, _ := range repo.Packages {
 				packages = append(packages, &repo.Packages[i])
 			}
-			err = resolver.LoadInvolvedPackages(packages, nil, nil, false)
+			model, err := resolver.LoadInvolvedPackages(packages, nil, nil, false)
 			g.Expect(err).ToNot(HaveOccurred())
-			err = resolver.ConstructRequirements([]string{pkg.Name})
+			err = resolver.ConstructRequirements(model, []string{pkg.Name})
 			g.Expect(err).ToNot(HaveOccurred())
-			_, _, _, err := resolver.Resolve()
+			_, _, _, err = resolver.Resolve(model)
 			if err != nil {
 				t.Fatalf("Failed to solve %s\n", pkg.Name)
 			}
@@ -1229,11 +1229,11 @@ func Test(t *testing.T) {
 			for i, _ := range repo.Packages {
 				packages = append(packages, &repo.Packages[i])
 			}
-			err = resolver.LoadInvolvedPackages(packages, nil, nil, tt.nobest)
+			model, err := resolver.LoadInvolvedPackages(packages, nil, nil, tt.nobest)
 			g.Expect(err).ToNot(HaveOccurred())
-			err = resolver.ConstructRequirements(tt.requires)
+			err = resolver.ConstructRequirements(model, tt.requires)
 			g.Expect(err).ToNot(HaveOccurred())
-			install, _, _, err := resolver.Resolve()
+			install, _, _, err := resolver.Resolve(model)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(pkgToString(install)).To(ConsistOf(tt.installs))
 		})
@@ -1385,16 +1385,16 @@ func TestNewResolver(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			resolver := NewResolver()
-			err := resolver.LoadInvolvedPackages(tt.packages, tt.ignoreRegex, tt.allowRegex, tt.nobest)
+			model, err := resolver.LoadInvolvedPackages(tt.packages, tt.ignoreRegex, tt.allowRegex, tt.nobest)
 			if err != nil {
 				t.Fail()
 			}
-			err = resolver.ConstructRequirements(tt.requires)
+			err = resolver.ConstructRequirements(model, tt.requires)
 			if err != nil {
 				fmt.Println(err)
 				t.Fail()
 			}
-			install, exclude, _, err := resolver.Resolve()
+			install, exclude, _, err := resolver.Resolve(model)
 			g := NewGomegaWithT(t)
 			if tt.solvable {
 				g.Expect(err).ToNot(HaveOccurred())

--- a/pkg/sat/sat_test.go
+++ b/pkg/sat/sat_test.go
@@ -22,13 +22,16 @@ func TestRecursive(t *testing.T) {
 	for _, pkg := range repo.Packages {
 		t.Run(fmt.Sprintf("find solution for %s", pkg.Name), func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			resolver := NewResolver()
 			packages := []*api.Package{}
 			for i, _ := range repo.Packages {
 				packages = append(packages, &repo.Packages[i])
 			}
-			model, err := resolver.LoadInvolvedPackages(packages, []string{pkg.Name}, nil, nil, false)
+
+			loader := NewLoader()
+			model, err := loader.Load(packages, []string{pkg.Name}, nil, nil, false)
 			g.Expect(err).ToNot(HaveOccurred())
+
+			resolver := NewResolver()
 			_, _, _, err = resolver.Resolve(model)
 			if err != nil {
 				t.Fatalf("Failed to solve %s\n", pkg.Name)
@@ -1222,13 +1225,16 @@ func Test(t *testing.T) {
 			err = xml.NewDecoder(f).Decode(repo)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			resolver := NewResolver()
 			packages := []*api.Package{}
 			for i, _ := range repo.Packages {
 				packages = append(packages, &repo.Packages[i])
 			}
-			model, err := resolver.LoadInvolvedPackages(packages, tt.requires, nil, nil, tt.nobest)
+
+			loader := NewLoader()
+			model, err := loader.Load(packages, tt.requires, nil, nil, tt.nobest)
 			g.Expect(err).ToNot(HaveOccurred())
+
+			resolver := NewResolver()
 			install, _, _, err := resolver.Resolve(model)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(pkgToString(install)).To(ConsistOf(tt.installs))
@@ -1380,11 +1386,13 @@ func TestNewResolver(t *testing.T) {
 			continue
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			resolver := NewResolver()
-			model, err := resolver.LoadInvolvedPackages(tt.packages, tt.requires, tt.ignoreRegex, tt.allowRegex, tt.nobest)
+			loader := NewLoader()
+			model, err := loader.Load(tt.packages, tt.requires, tt.ignoreRegex, tt.allowRegex, tt.nobest)
 			if err != nil {
 				t.Fail()
 			}
+
+			resolver := NewResolver()
 			install, exclude, _, err := resolver.Resolve(model)
 			g := NewGomegaWithT(t)
 			if tt.solvable {

--- a/pkg/sat/sat_test.go
+++ b/pkg/sat/sat_test.go
@@ -31,8 +31,7 @@ func TestRecursive(t *testing.T) {
 			model, err := loader.Load(packages, []string{pkg.Name}, nil, nil, false)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			resolver := NewResolver()
-			_, _, _, err = resolver.Resolve(model)
+			_, _, _, err = Resolve(model)
 			if err != nil {
 				t.Fatalf("Failed to solve %s\n", pkg.Name)
 			}
@@ -1234,8 +1233,7 @@ func Test(t *testing.T) {
 			model, err := loader.Load(packages, tt.requires, nil, nil, tt.nobest)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			resolver := NewResolver()
-			install, _, _, err := resolver.Resolve(model)
+			install, _, _, err := Resolve(model)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(pkgToString(install)).To(ConsistOf(tt.installs))
 		})
@@ -1392,8 +1390,7 @@ func TestNewResolver(t *testing.T) {
 				t.Fail()
 			}
 
-			resolver := NewResolver()
-			install, exclude, _, err := resolver.Resolve(model)
+			install, exclude, _, err := Resolve(model)
 			g := NewGomegaWithT(t)
 			if tt.solvable {
 				g.Expect(err).ToNot(HaveOccurred())

--- a/tools/integrity.bzl
+++ b/tools/integrity.bzl
@@ -1,11 +1,11 @@
 "Generated during release by release_prep.sh, using integrity.jq"
 
 INTEGRITY = {
-    "darwin-amd64": "92afc7f6475981adf9ae32b563b051869d433d8d8c9666e28a1c1c6e840394cd",
-    "darwin-arm64": "c5e99ed72448026ee63259a0a28440f8b43a125414fa312edbd569c2976515a3",
-    "linux-amd64": "7e1035d8bd2f25b787b04843f4d6a05e7cdbd3995926497c2a587e52da6262a8",
-    "linux-arm64": "d954b785bfd79dbbd66a2f3df02b0d3a51f1fed4508a6d88fda13a9d24c878cc",
-    "linux-ppc64": "9d5337c1afe4bab858742718ac4c230d9ca368299cb97c50078eef14ae180922",
-    "linux-ppc64le": "7ea4db00947914bc1c51e8f042fe220a3167c65815c487eccd0c541ecfa78aa1",
-    "linux-s390x": "09aa4abcb1d85da11642889826b982ef90547eb32099fc8177456c92f66a4cfd",
+    "darwin-amd64": "fc101a75d6c20d3d6b6678c8dceaaae722511b0400432999795d17becf88a648",
+    "darwin-arm64": "fdf44a02d07df0c08398fecc3758d16bb50ce4cf09a3495fa27d08028bfcb6e4",
+    "linux-amd64": "6457c75de4ab79bda2038eb8d1a411dc9253dae28359d32f4df3decadc4f92e9",
+    "linux-arm64": "f2dacd2a1ef78ba5ae8176e2a150e7ed0cb0dc7d8c45f0b7dd3306954578739d",
+    "linux-ppc64": "e1e66dac1024c721b1d0d832b61fbdee4f87bfdea82c886fcec5a242851f4b97",
+    "linux-ppc64le": "961fa2992ab1bab16bc15320bb3d74aebc5dd94b7c015488558ec9963f74ada2",
+    "linux-s390x": "a9fce33d16b9f30f45a7831b5b677b939bdc7a4723258811b0651e109156e86a",
 }

--- a/tools/version.bzl
+++ b/tools/version.bzl
@@ -1,5 +1,5 @@
 "Generated during release generate_tools_prebuilts.sh"
 
-VERSION = "v0.5.9"
+VERSION = "v0.99.1"
 
 REPO_URL = "rmohr/bazeldnf"


### PR DESCRIPTION
This change breaks the SAT solver into two separate loading and resolving steps which will make it easier to test the pieces individually.  The data tracked for the SAT solver is also separated into a distinct Model type which is built up by the Loader and consumed by the Resolver.