### PR TITLE
Update default tools versions

### DIFF
--- a/tools/integrity.bzl
+++ b/tools/integrity.bzl
@@ -1,11 +1,11 @@
 "Generated during release by release_prep.sh, using integrity.jq"
 
 INTEGRITY = {
-    "darwin-amd64": "92afc7f6475981adf9ae32b563b051869d433d8d8c9666e28a1c1c6e840394cd",
-    "darwin-arm64": "c5e99ed72448026ee63259a0a28440f8b43a125414fa312edbd569c2976515a3",
-    "linux-amd64": "7e1035d8bd2f25b787b04843f4d6a05e7cdbd3995926497c2a587e52da6262a8",
-    "linux-arm64": "d954b785bfd79dbbd66a2f3df02b0d3a51f1fed4508a6d88fda13a9d24c878cc",
-    "linux-ppc64": "9d5337c1afe4bab858742718ac4c230d9ca368299cb97c50078eef14ae180922",
-    "linux-ppc64le": "7ea4db00947914bc1c51e8f042fe220a3167c65815c487eccd0c541ecfa78aa1",
-    "linux-s390x": "09aa4abcb1d85da11642889826b982ef90547eb32099fc8177456c92f66a4cfd",
+    "darwin-amd64": "fc101a75d6c20d3d6b6678c8dceaaae722511b0400432999795d17becf88a648",
+    "darwin-arm64": "fdf44a02d07df0c08398fecc3758d16bb50ce4cf09a3495fa27d08028bfcb6e4",
+    "linux-amd64": "6457c75de4ab79bda2038eb8d1a411dc9253dae28359d32f4df3decadc4f92e9",
+    "linux-arm64": "f2dacd2a1ef78ba5ae8176e2a150e7ed0cb0dc7d8c45f0b7dd3306954578739d",
+    "linux-ppc64": "e1e66dac1024c721b1d0d832b61fbdee4f87bfdea82c886fcec5a242851f4b97",
+    "linux-ppc64le": "961fa2992ab1bab16bc15320bb3d74aebc5dd94b7c015488558ec9963f74ada2",
+    "linux-s390x": "a9fce33d16b9f30f45a7831b5b677b939bdc7a4723258811b0651e109156e86a",
 }

--- a/tools/version.bzl
+++ b/tools/version.bzl
@@ -1,5 +1,5 @@
 "Generated during release generate_tools_prebuilts.sh"
 
-VERSION = "v0.5.9"
+VERSION = "v0.99.1"
 
 REPO_URL = "rmohr/bazeldnf"


### PR DESCRIPTION
This change pulls the updated tools versions as v0.99.1 by default.