### PR TITLE
Allow `tar2files` running in external repo

### DIFF
--- a/e2e/bazel-bzlmod/BUILD.bazel
+++ b/e2e/bazel-bzlmod/BUILD.bazel
@@ -12,6 +12,7 @@ rpmtree(
         "@libvirt-libs-11.0.0-1.fc42.x86_64.rpm//rpm",
         "@libvirt-devel-11.0.0-1.fc42.x86_64.rpm//rpm",
     ],
+    visibility = ["//visibility:public"],
 )
 
 tar2files(
@@ -43,4 +44,12 @@ sh_binary(
     env = {
         "BAZELDNF_PATH": "$(location :bazeldnf)",
     },
+)
+
+filegroup(
+    name = "extracted_in_external_repo",
+    srcs = [
+        "@repo1//:something_libs/usr/lib64/libvirt.so.0",
+        "@repo1//:something_libs/usr/lib64/libvirt.so.0.11000.0",
+    ],
 )

--- a/e2e/bazel-bzlmod/MODULE.bazel
+++ b/e2e/bazel-bzlmod/MODULE.bazel
@@ -32,3 +32,8 @@ use_repo(
 )
 
 bazel_dep(name = "rules_cc", version = "0.1.1", dev_dependency = True)
+
+# Tests
+repo1 = use_repo_rule("//:repo_rules.bzl", "repo1")
+
+repo1(name = "repo1")

--- a/e2e/bazel-bzlmod/repo_rules.bzl
+++ b/e2e/bazel-bzlmod/repo_rules.bzl
@@ -1,0 +1,26 @@
+""" Rules generating repositories for testing. """
+
+def _repo1_impl(rctx):
+    rctx.file(
+        "BUILD.bazel",
+        """
+load("@bazeldnf//bazeldnf:defs.bzl", "tar2files")
+
+# This tests if `tar2files` can be called in an external repo
+tar2files(
+    name = "something_libs",
+    files = {
+        "/usr/lib64": [
+            "libvirt.so.0",
+            "libvirt.so.0.11000.0",
+        ],
+    },
+    tar = "@//:something",
+    visibility = ["//visibility:public"],
+)
+""",
+    )
+
+repo1 = repository_rule(
+    implementation = _repo1_impl,
+)

--- a/internal/rpmtree.bzl
+++ b/internal/rpmtree.bzl
@@ -75,6 +75,7 @@ def _tar2files_impl(ctx):
     args = ctx.actions.args()
     strip_prefix = paths.join(
         ctx.bin_dir.path,
+        ctx.label.workspace_root,
         ctx.label.package,
         ctx.label.name,
     )


### PR DESCRIPTION
In such case the `--strip-prefix` requires precise path also involving workspace root.