### PR TITLE
Fix `explodePackageRequires` to correctly handle case when requirement can't be satisfied

### DIFF
--- a/pkg/sat/sat_test.go
+++ b/pkg/sat/sat_test.go
@@ -1376,6 +1376,16 @@ func TestNewResolver(t *testing.T) {
 			exclude:    []string{},
 			solvable:   true,
 		},
+		{name: "second missing dependency on list should fail", packages: []*api.Package{
+			newPkg("testa", "1", []string{}, []string{"testb", "missing"}, []string{}),
+			newPkg("testb", "1", []string{}, []string{}, []string{}),
+		}, requires: []string{
+			"testa",
+		},
+			install:  []string{},
+			exclude:  []string{},
+			solvable: false,
+		},
 
 		// Multi-arch:
 		{name: "prioritize top-level: best arch & version", packages: []*api.Package{


### PR DESCRIPTION
The previous implementation in this case returned `bf.Not(bfunique)`, which was reasonable in the first iteration of the loop, creating var → ¬var
to prevent that variable (package) from being chosen.

Unfortunately, `bfunique` could accumulate some other formulas and past the first iteration this is no longer correct.

In addition, the logic was split into two-phase pass, to report all missing dependencies, not only the first one.