### PR TITLE
Add option to ignore missing lockfile (and generate null RPM repositories)

### DIFF
--- a/bazeldnf/extensions.bzl
+++ b/bazeldnf/extensions.bzl
@@ -205,6 +205,9 @@ def _handle_lock_file(config, module_ctx, registered_rpms = {}):
         # so that consumers have something consistent that they can depend on
         for target in lock_file_json.get("targets", []):
             ensure_rpm_repository[target] = True
+    elif config.ignore_missing_lockfile:
+        for target in config.rpms:
+            ensure_rpm_repository[target] = True
 
     for target in ensure_rpm_repository:
         _add_null_rpm_repository(config, target, registered_rpms)
@@ -383,6 +386,12 @@ The lock file content is as:
 ```
 """,
             allow_single_file = [".json"],
+        ),
+        "ignore_missing_lockfile": attr.bool(
+            doc = """In case lockfile does not exist, create null rpm targets so that clients can still depend on them.
+
+            One won't be prompted with "please run `bazel run @{repo}//:update-lock-file` first".""",
+            default = False,
         ),
         "rpm_repository_prefix": attr.string(
             doc = "A prefix to add to all generated rpm repositories",

--- a/e2e/bazel-bzlmod-lock-file/BUILD.bazel
+++ b/e2e/bazel-bzlmod-lock-file/BUILD.bazel
@@ -36,3 +36,10 @@ cc_library(
     name = "bar",
     srcs = ["//:something_libs/usr/lib64"],
 )
+
+filegroup(
+    name = "test-no-lockfile",
+    srcs = [
+        "@bazeldnf-no-lockfile//bash",
+    ],
+)

--- a/e2e/bazel-bzlmod-lock-file/MODULE.bazel
+++ b/e2e/bazel-bzlmod-lock-file/MODULE.bazel
@@ -71,8 +71,19 @@ bazeldnf.config(
     name = "bazeldnf-others",
     lock_file = "//:rpms-with-no-name-attribute.json",
 )
+bazeldnf.config(
+    name = "bazeldnf-no-lockfile",
+    ignore_missing_lockfile = True,
+    lock_file = "//:does-not-exist.json",
+    repofile = "//:repo.yaml",
+    rpm_repository_prefix = "no-lockfile",
+    rpms = [
+        "bash",
+    ],
+)
 use_repo(
     bazeldnf,
+    "bazeldnf-no-lockfile",
     "bazeldnf-others",
     "bazeldnf-rpms",
 )


### PR DESCRIPTION
Some use cases may require running queries over the build graph prior to having the correct lockfile.
Such queries would fail if they refer to targets/aliases yet to be created.

This change basically extends the logic of null RPM repositories for unresolved packages (in presence of lockfile) to all packages (in absence of lockfile).
As it silences the message about the need to update lock file, it's not the default behaviour and is enabled with `ignore_missing_lockfile` attr of the `config` tag.