### PR TITLE
Correct the number of vars in formula for test

### DIFF
--- a/pkg/sat/loader_test.go
+++ b/pkg/sat/loader_test.go
@@ -51,7 +51,7 @@ func expectedIgnores(g *WithT, m *Model, pkgKeys ...api.PackageKey) {
 }
 
 func expectedAnds(g *WithT, m *Model, ands ...bf.Formula) {
-	n := len(ands)
+	n := len(m.vars)
 	permutations := int(math.Pow(2, float64(n)))
 
 	for i := 0; i < permutations; i++ {


### PR DESCRIPTION
It was relying on the number of top-level AND clauses in the test, which does not really correspond to the number of vars.