### PR TITLE
Add support for the riscv64 platform

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,7 +23,7 @@ bazel_dep(name = "bazel_features", version = "1.26.0")
 
 # if someone wants to build the bazeldnf toolchain from sources needs this set of dependencies
 bazel_dep(name = "gazelle", version = "0.42.0")
-bazel_dep(name = "rules_go", version = "0.53.0")
+bazel_dep(name = "rules_go", version = "0.59.0")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
 go_sdk.download(version = "1.24.1")

--- a/bazeldnf/platforms.bzl
+++ b/bazeldnf/platforms.bzl
@@ -45,4 +45,10 @@ PLATFORMS = {
             "@platforms//cpu:s390x",
         ],
     ),
+    "linux-riscv64": struct(
+        compatible_with = [
+            "@platforms//os:linux",
+            "@platforms//cpu:riscv64",
+        ],
+    ),
 }

--- a/e2e/bazel-bzlmod-lock-file-from-args/MODULE.bazel
+++ b/e2e/bazel-bzlmod-lock-file-from-args/MODULE.bazel
@@ -9,7 +9,7 @@ local_path_override(
 )
 
 bazel_dep(name = "rules_pkg", version = "1.0.1")
-bazel_dep(name = "rules_go", version = "0.53.0", repo_name = "rules_go")
+bazel_dep(name = "rules_go", version = "0.59.0", repo_name = "rules_go")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.24.1")

--- a/e2e/bazel-bzlmod-lock-file/MODULE.bazel
+++ b/e2e/bazel-bzlmod-lock-file/MODULE.bazel
@@ -9,7 +9,7 @@ local_path_override(
 )
 
 bazel_dep(name = "rules_pkg", version = "1.0.1")
-bazel_dep(name = "rules_go", version = "0.53.0", repo_name = "rules_go")
+bazel_dep(name = "rules_go", version = "0.59.0", repo_name = "rules_go")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.24.1")

--- a/e2e/bazel-bzlmod-toolchain-from-source/MODULE.bazel
+++ b/e2e/bazel-bzlmod-toolchain-from-source/MODULE.bazel
@@ -9,7 +9,7 @@ local_path_override(
 )
 
 bazel_dep(name = "rules_pkg", version = "1.0.1")
-bazel_dep(name = "rules_go", version = "0.53.0", repo_name = "rules_go")
+bazel_dep(name = "rules_go", version = "0.59.0", repo_name = "rules_go")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.24.1")

--- a/e2e/bzlmod-toolchain-circular-dependencies/MODULE.bazel
+++ b/e2e/bzlmod-toolchain-circular-dependencies/MODULE.bazel
@@ -9,7 +9,7 @@ local_path_override(
 )
 
 bazel_dep(name = "rules_pkg", version = "1.0.1")
-bazel_dep(name = "rules_go", version = "0.53.0", repo_name = "rules_go")
+bazel_dep(name = "rules_go", version = "0.59.0", repo_name = "rules_go")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.24.1")

--- a/tools/integrity.bzl
+++ b/tools/integrity.bzl
@@ -8,4 +8,5 @@ INTEGRITY = {
     "linux-ppc64": "e1e66dac1024c721b1d0d832b61fbdee4f87bfdea82c886fcec5a242851f4b97",
     "linux-ppc64le": "961fa2992ab1bab16bc15320bb3d74aebc5dd94b7c015488558ec9963f74ada2",
     "linux-s390x": "a9fce33d16b9f30f45a7831b5b677b939bdc7a4723258811b0651e109156e86a",
+    "linux-riscv64": "b29ccd8b8f31f00e327da7535cd8c8bb96cc0c3eda41ebb963ad722784f8c2b2",
 }


### PR DESCRIPTION
Hi there,

Recently, riscv64 has gained widespread adoption, so we might consider adding support for it. I recently submitted a relatively simple [PR](https://github.com/bazel-contrib/rules_go/pull/4507) to **rules_go**, which allows it to support riscv64 to some extent—upgrading to **v0.59.0** is sufficient to enable this.

I ran the CI in my fork, and everything went smoothly. The results are as follows:

* [Release](https://github.com/ffgan/bazeldnf/actions/runs/19284371998)
* [Linters](https://github.com/ffgan/bazeldnf/actions/runs/19284371992)
* [Build and test](https://github.com/ffgan/bazeldnf/actions/runs/19284371979)

Since I couldn’t find existing tests for architectures other than **amd64** and **arm64**, I haven’t added any riscv64-specific tests for now. I believe this PR should work fine on riscv64 as well.

Technically, we could run tests for other architectures using a **qemu + docker** setup, but that would also require building Bazel for the corresponding architecture in advance. Those steps are outside the scope of this PR, but if needed, I can open a separate PR to implement that.

if any maintainers have questions, feel free to @ me — I’d be happy to answer any related questions.





---
Other Info
Co-authored by: nijincheng@iscas.ac.cn;
Co-authored by: 1768549509@qq.com;