### PR TITLE
Enforce single version constraint per package

### DIFF
--- a/pkg/sat/loader_test.go
+++ b/pkg/sat/loader_test.go
@@ -226,7 +226,7 @@ func TestLoader_Load(t *testing.T) {
 			expectedBest(g, model, map[string]string{"A": "0:2.0-1"})
 			expectedIgnores(g, model)
 			expectedAnds(g, model,
-				bf.True, // Nothing to install
+				bf.Not(bf.And(x1, x2)), // No more than one `A`
 			)
 		})
 	})
@@ -607,30 +607,39 @@ func TestLoader_Load(t *testing.T) {
 			allB = append(allB, newSimplePackage("B", v))
 		}
 
+		atMostOneB := bf.Not(bf.Or(
+			bf.And(x2, x3),
+			bf.And(x2, x4),
+			bf.And(x2, x5),
+			bf.And(x3, x4),
+			bf.And(x3, x5),
+			bf.And(x4, x5),
+		))
+
 		eqExpectedAnds := []bf.Formula{
 			x1,                 // Install: A
 			bf.Implies(x1, x4), // Requirement: A => B eq 2.0-2
+			atMostOneB,
 		}
 		gtExpectedAnds := []bf.Formula{
 			x1,                 // Install: A
 			bf.Implies(x1, x5), // Requirement: A => B gt 2.0-2
+			atMostOneB,
 		}
 		ltExpectedAnds := []bf.Formula{
 			x1,                            // Install: A
 			bf.Implies(x1, bf.Or(x2, x3)), // Requirement: A => B lt 2.0-2
-			bf.Not(bf.And(x2, x3)),
+			atMostOneB,
 		}
 		geExpectedAnds := []bf.Formula{
 			x1,                            // Install: A
 			bf.Implies(x1, bf.Or(x4, x5)), // Requirement: A => B ge 2.0-2
-			bf.Not(bf.And(x4, x5)),
+			atMostOneB,
 		}
 		leExpectedAnds := []bf.Formula{
 			x1,                                // Install: A
 			bf.Implies(x1, bf.Or(x2, x3, x4)), // Requirement: A => B le 2.0-2
-			bf.Not(bf.And(x2, x3)),
-			bf.Not(bf.And(x2, x4)),
-			bf.Not(bf.And(x3, x4)),
+			atMostOneB,
 		}
 
 		testCases := []struct {

--- a/pkg/sat/sat_test.go
+++ b/pkg/sat/sat_test.go
@@ -1386,6 +1386,16 @@ func TestNewResolver(t *testing.T) {
 			exclude:  []string{},
 			solvable: false,
 		},
+		{name: "don't install the same package in multiple versions", packages: []*api.Package{
+			newPkg("testa", "1", []string{}, []string{"b", "c"}, []string{}),
+			newPkg("testb", "1.1", []string{"b"}, []string{}, []string{}),
+			newPkg("testb", "1.2", []string{"c"}, []string{}, []string{}),
+		}, requires: []string{
+			"testa",
+		},
+			solvable: false,
+			nobest:   true,
+		},
 
 		// Multi-arch:
 		{name: "prioritize top-level: best arch & version", packages: []*api.Package{


### PR DESCRIPTION
So far the only constraint for not installing multiple packages of the same name came from `explodePackageRequires` that for each requirement required that at most one package version was satisfying it (`bf.Unique`). However, this relied on packages being requested explicitly by name. If not, there was no other constraint limiting that.

Since, later in the code, resolved packages are referenced solely by name, selecting multiple versions resulted in alternate versions being overwritten or otherwise ignored.

In the future, this constraint may be relaxed to allow multiple variants of the same package if they differ by architecture.