### PR TITLE
Remove incorrect dependency ignore check

### DIFF
--- a/cmd/config_helper.go
+++ b/cmd/config_helper.go
@@ -95,10 +95,6 @@ func collectProviders(pkgSets ...[]*api.Package) map[string]string {
 func collectDependencies(pkg string, requires []string, providers map[string]string, ignored map[string]bool) ([]string, error) {
 	depSet := make(map[string]bool)
 	for _, req := range requires {
-		if ignored[req] {
-			logrus.Debugf("Ignoring dependency %s", req)
-			continue
-		}
 		logrus.Debugf("Resolving dependency %s", req)
 		provider, ok := providers[req]
 		if !ok {


### PR DESCRIPTION
The removed code attempted to check if a required resource (`req`) was in the `ignored` packages set. This is a type error: `req` represents a resource name (e.g. package, file path, or capability), while `ignored` is a set of package names.

Even when `req` happens to be a package name, checking it directly against `ignored` is semantically wrong – we need to resolve which package provides that requirement first, then check if that `provider` package is ignored.

The type error was hidden because everything was implemented using plain strings instead of stronger typing that would have caught this mismatch.

The correct check already exists where the resolved `provider` package name is compared against the `ignored` set.