### PR TITLE
Trim correct prefix from links

### DIFF
--- a/pkg/rpm/tar.go
+++ b/pkg/rpm/tar.go
@@ -110,7 +110,10 @@ func PrefixFilter(prefix, strip string, reader *tar.Reader, files []string) erro
 				return err
 			}
 		case tar.TypeSymlink:
-			linkname := strings.TrimPrefix(entry.Linkname, ".")
+			linkname := entry.Linkname
+			if strings.HasPrefix(linkname, "./") {
+				linkname = strings.TrimPrefix(linkname, "./")
+			}
 			err = os.Symlink(linkname, fileMap[name])
 			if err != nil {
 				return err


### PR DESCRIPTION
If we trim `.` unilaterally from linknames we kill stuff like `../foo` where it looks like the intent is to just simplify relative prefixes. This change conditionally removes `./` instead.