### PR TITLE
Allow extraction of directories with tar2files

### DIFF
--- a/pkg/rpm/tar.go
+++ b/pkg/rpm/tar.go
@@ -127,6 +127,11 @@ func PrefixFilter(prefix, strip string, reader *tar.Reader, files []string) erro
 			if err := os.Symlink(rel, fileMap[name]); err != nil {
 				return err
 			}
+		case tar.TypeDir:
+			err = os.MkdirAll(fileMap[name], entry.FileInfo().Mode())
+			if err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("can't extract %v with type %v: only links, symlinks and files can be specified", fileMap[name], entry.Typeflag)
 		}

--- a/pkg/rpm/tar_test.go
+++ b/pkg/rpm/tar_test.go
@@ -195,6 +195,19 @@ func TestTar2Files(t *testing.T) {
 				}},
 			},
 			prefix: "./usr/include/",
+		},
+		{
+			name:  "extract a dir from a tar archive",
+			rpm:   libvirtLibsRpm,
+			files: []string{"/usr/share/libvirt"},
+			expected: []fileInfo{
+				{Name: "usr", Children: []fileInfo{
+					{Name: "share", Children: []fileInfo{
+						{Name: "libvirt", Children: []fileInfo{}},
+					}},
+				}},
+			},
+			prefix: "./usr/share/",
 		}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
RPMs may contain standalone directories as well as links and files and for some cases we'll want to extract them (eg: if they happen to be empty directories that a symlink points to).  This change lets us explicitly extract them.