### PR TITLE
Handle multiple packages providing the same capability in config generator

### DIFF
--- a/cmd/config_helper_test.go
+++ b/cmd/config_helper_test.go
@@ -105,6 +105,16 @@ func newPackageWithFiles(name string, files ...string) *api.Package {
 	return p
 }
 
+func newPackageWithProvides(name string, provides ...string) *api.Package {
+	p := newSimplePackage(name)
+	p.Format.Provides.Entries = []api.Entry{{Name: name}}
+	for _, provide := range provides {
+		p.Format.Provides.Entries = append(p.Format.Provides.Entries, api.Entry{Name: provide})
+	}
+
+	return p
+}
+
 func newSimpleRPM(name string, deps ...string) *bazeldnf.RPM {
 	d := []string{}
 	if len(deps) > 0 {
@@ -396,6 +406,22 @@ func TestConfigTransform(t *testing.T) {
 			},
 			expectedRPMs: []*bazeldnf.RPM{
 				newSimpleRPM("package1"),
+			},
+		},
+		{
+			name: "multiple providers",
+			installed: []*api.Package{
+				newPackageWithDeps("package1", "webserver"),
+				newPackageWithProvides("apache", "webserver"),
+				newPackageWithProvides("nginx", "webserver"),
+			},
+			expectedRepositories: map[string][]string{
+				"repository": []string{},
+			},
+			expectedRPMs: []*bazeldnf.RPM{
+				newSimpleRPM("apache"),
+				newSimpleRPM("nginx"),
+				newSimpleRPM("package1", "apache", "nginx"),
 			},
 		},
 	}


### PR DESCRIPTION
A given capability can theoretically be fulfilled by multiple distinct packages selected for installation. Common cases include:
- generic capabilities like "webserver" having multiple implementations installed;
- packages required by name, but installed in multiple architectures. The multiple providers might result from an explicit requirement, or a transitive dependency of another package.

Currently, it is unlikely that such data reaches the config generator because the SAT formula mandates exactly one provider for each capability. This change enables the relaxation of this constraint to allow more than one provider.

Now there's a problem how to handle the multiple providers when the config file (lock file) is generated and how the `Dependencies` should be populated. There are at least three options:
1. Unspecified – the current implementation; any subsequent providing package just overrides the previous one.
2. All – the requiring package can choose from multiple provided dependncies.
3. Specific logic – either user providing preferred provider, or maybe choosing first one in the alphabet, or some other logic.

This change implements the *All* option, argumenting that extra logic would make the construction of the lockfile unnecessarily complex. *All* also resembles more closely how the `dnf` works on the actual system – where the filesystem exposes all installed packages to any consumer. While this involves a trade-off of declaring more dependencies than strictly necessary for specific use cases, it ensures correctness without extra user input.