### PR TITLE
rpmtree: support gzip compression

### DIFF
--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -14,14 +14,15 @@ import (
 )
 
 type rpmtreeOpts struct {
-	repofiles  []string
-	workspace  string
-	toMacro    string
-	buildfile  string
-	configname string
-	lockfile   string
-	name       string
-	public     bool
+	repofiles   []string
+	workspace   string
+	toMacro     string
+	buildfile   string
+	configname  string
+	lockfile    string
+	name        string
+	public      bool
+	compression string
 }
 
 var rpmtreeopts = rpmtreeOpts{}
@@ -162,7 +163,7 @@ func NewRpmTreeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			bazel.AddTree(rpmtreeopts.name, configname, build, install, rpmtreeopts.public)
+			bazel.AddTree(rpmtreeopts.name, configname, build, install, rpmtreeopts.public, rpmtreeopts.compression)
 
 			if err := handler.Process(install, build); err != nil {
 				return err
@@ -194,6 +195,7 @@ func NewRpmTreeCmd() *cobra.Command {
 	rpmtreeCmd.Flags().StringVar(&rpmtreeopts.configname, "configname", "rpms", "config name to use in lockfile")
 	rpmtreeCmd.Flags().StringVar(&rpmtreeopts.lockfile, "lockfile", "", "lockfile for RPMs")
 	rpmtreeCmd.Flags().StringVar(&rpmtreeopts.name, "name", "", "rpmtree rule name")
+	rpmtreeCmd.Flags().StringVar(&rpmtreeopts.compression, "compression", "", "Compression algorithm to use on resulting archive (e.g., gzip)")
 	rpmtreeCmd.MarkFlagRequired("name")
 
 	repo.AddCacheHelperFlags(rpmtreeCmd)

--- a/internal/rpmtree.bzl
+++ b/internal/rpmtree.bzl
@@ -47,6 +47,9 @@ def _rpm2tar_impl(ctx):
             selinux_labels.append(k + "=" + v)
         args.add_joined("--selinux-labels", selinux_labels, join_with = ",")
 
+    if ctx.attr.compression:
+        args.add("--compression", ctx.attr.compression)
+
     all_rpms = []
 
     for target in ctx.attr.rpms:
@@ -110,6 +113,7 @@ _rpm2tar_attrs = {
     "capabilities": attr.string_list_dict(),
     "selinux_labels": attr.string_list_dict(),
     "out": attr.output(mandatory = True),
+    "compression": attr.string(),
 }
 
 _tar2files_attrs = {
@@ -130,9 +134,19 @@ _tar2files = rule(
     toolchains = [BAZELDNF_TOOLCHAIN],
 )
 
-def rpmtree(name, **kwargs):
-    """Creates a tar file from a list of rpm files."""
-    tarname = name + ".tar"
+def rpmtree(name, compression = None, **kwargs):
+    """Creates a tar file from a list of rpm files.
+
+    Args:
+      name: The name of the target.
+      compression: The compression algorithm to use (e.g. 'gzip'). Defaults to None.
+      **kwargs: Additional keyword arguments to be passed to the _rpm2tar function (e.g. rpms, symlinks).
+    """
+    extension = ".tar"
+    if compression == "gzip":
+        extension = ".tar.gz"
+
+    tarname = name + extension
     _rpm2tar(
         name = name,
         out = tarname,

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -268,7 +268,7 @@ func AddTar2Files(name string, rpmtree string, buildfile *build.File, files []st
 	}
 }
 
-func AddTree(name, configname string, buildfile *build.File, pkgs []*api.Package, public bool) {
+func AddTree(name, configname string, buildfile *build.File, pkgs []*api.Package, public bool, compression string) {
 	transform := func(n string) string {
 		return "@" + n + "//rpm"
 	}
@@ -302,6 +302,11 @@ func AddTree(name, configname string, buildfile *build.File, pkgs []*api.Package
 	}
 	rule.SetName(name)
 	rule.SetRPMs(rpms)
+
+	if compression != "" {
+		rule.SetAttr("compression", &build.StringExpr{Value: compression})
+	}
+
 	if public {
 		rule.SetAttr("visibility", &build.ListExpr{List: []build.Expr{&build.StringExpr{Value: "//visibility:public"}}})
 	}


### PR DESCRIPTION
Currently, users must rely on pkg_tar to compress the archive generated by rpmtree. However, the unpacking and repacking process in pkg_tar can introduce duplicate file entires, which causes failures in downstream consumers like rules_oci.

This PR adds a --compression flag to rpmtree, allowing it to output compressed archives (e.g., gzip) directly, bypassing the need for an intermediate pkg_tar step.
