### PR TITLE
Relax requirement constraints from Unique to Or

### DIFF
--- a/pkg/sat/loader.go
+++ b/pkg/sat/loader.go
@@ -238,20 +238,20 @@ func (loader *Loader) explodePackageRequires(pkgVar *Var) bf.Formula {
 		return bf.False
 	}
 
-	var uniqueRequirements []bf.Formula
+	var orRequirements []bf.Formula
 	for _, satisfies := range requirements {
-		uniqueVars := []string{}
+		vars := []bf.Formula{}
 		for _, s := range satisfies {
-			uniqueVars = append(uniqueVars, s.satVarName)
+			vars = append(vars, bf.Var(s.satVarName))
 		}
-		uniqueRequirements = append(uniqueRequirements, bf.Unique(uniqueVars...))
+		orRequirements = append(orRequirements, bf.Or(vars...))
 	}
 
-	if uniqueRequirements == nil {
+	if orRequirements == nil {
 		// empty `bf.And` doesn't work as expected, hence this special case:
 		return bf.True
 	}
-	return bf.And(uniqueRequirements...)
+	return bf.And(orRequirements...)
 }
 
 func (loader *Loader) explodePackageConflicts(pkgVar *Var) bf.Formula {

--- a/pkg/sat/loader_test.go
+++ b/pkg/sat/loader_test.go
@@ -394,7 +394,6 @@ func TestLoader_Load(t *testing.T) {
 				bf.Implies(x3, bf.Or(x1, x4)), // Requirement: app => apache or nginx
 				bf.Eq(x1, x2),                 // Equivalence (apache)
 				bf.Eq(x4, x5),                 // Equivalence (nginx)
-				bf.Not(bf.And(x1, x4)),        // No more than one provider of `webserver`
 			)
 		})
 
@@ -504,7 +503,6 @@ func TestLoader_Load(t *testing.T) {
 				bf.Eq(x1, x2),                 // Equivalence (gcc)
 				bf.Eq(x3, x4),                 // Equivalence (gcc11)
 				bf.Eq(x3, x5),                 // Equivalence (gcc11)
-				bf.Not(bf.And(x1, x3)),        // No more than one provider of `gcc`
 			)
 
 		})

--- a/pkg/sat/sat_test.go
+++ b/pkg/sat/sat_test.go
@@ -1396,6 +1396,27 @@ func TestNewResolver(t *testing.T) {
 			solvable: false,
 			nobest:   true,
 		},
+		{name: "install two providers (requested explicitly)", packages: []*api.Package{
+			newPkg("testa", "1", []string{}, []string{"lib"}, []string{}),
+			newPkg("libb", "1", []string{"lib"}, []string{}, []string{}),
+			newPkg("libc", "1", []string{"lib"}, []string{}, []string{}),
+		}, requires: []string{
+			"testa", "libb", "libc",
+		},
+			install:  []string{"testa-0:1", "libb-0:1", "libc-0:1"},
+			solvable: true,
+		},
+		{name: "install two providers (dependencies)", packages: []*api.Package{
+			newPkg("testa", "1", []string{}, []string{"lib"}, []string{}),
+			newPkg("testb", "1", []string{}, []string{"libb", "libc"}, []string{}),
+			newPkg("libb", "1", []string{"lib"}, []string{}, []string{}),
+			newPkg("libc", "1", []string{"lib"}, []string{}, []string{}),
+		}, requires: []string{
+			"testa", "testb",
+		},
+			install:  []string{"testa-0:1", "testb-0:1", "libb-0:1", "libc-0:1"},
+			solvable: true,
+		},
 
 		// Multi-arch:
 		{name: "prioritize top-level: best arch & version", packages: []*api.Package{


### PR DESCRIPTION
[actually, a reiteration of #142]

Currently, the solver enforces a Unique constraint on requirements. This assumption – that a requirement can only be satisfied by a single entity in the graph – is too restrictive for complex dependency graphs. Specifically, it prevents valid configurations where multiple distinct packages satisfy the same generic interface, or where the same package is required across different architectures. In these scenarios, the strict uniqueness constraint causes the resolution to fail with a *no solution found* error.

With generic requirements, such as a `webserver`, it should be legal for multiple providers to coexist. While a simple dependency graph might resolve to a single preferred webserver (unspecified which one – in case of no particular requirements), more complex scenarios may necessitate multiple providers. For instance, different packages might require specific, distinct webserver implementations, or multiple webservers can be explicitly requested.

Furthermore, this relaxation is requisite for multi-architecture support (see proposal #166). When a package is requested by name alone, the user typically implies indifference to the architecture. However, the dependency graph may legitimately require that same package to be installed for multiple distinct architectures simultaneously.

Historically, the Unique constraint was likely intended to prevent version conflicts or ambiguous provider selection. These specific concerns were addressed in prior changes (see #164 and #169).