### PR TITLE
Materialise RPM identifier in lockfile

### DIFF
--- a/bazeldnf/extensions.bzl
+++ b/bazeldnf/extensions.bzl
@@ -228,14 +228,16 @@ def _add_rpm_repository(config, rpm, lock_file_json, registered_rpms):
         dependencies = [x.replace("+", "plus") for x in dependencies]
         dependencies = ["@{}{}//rpm".format(config.rpm_repository_prefix, x) for x in dependencies]
 
-    rpm_name = rpm.pop("name", None)
-    if not rpm_name:
+    # Older lockfiles may not have `id` field.
+    # Name was the equivalent. We need to pop both.
+    id = rpm.pop("id", rpm.pop("name", None))
+    if not id:
         urls = rpm.get("urls", [])
         if len(urls) < 1:
-            fail("invalid entry in %s for %s" % (config.lock_file, rpm_name))
-        rpm_name = urls[0].rsplit("/", 1)[-1]
+            fail("invalid entry in %s: %s" % (config.lock_file, rpm))
+        id = urls[0].rsplit("/", 1)[-1]
 
-    name = _to_rpm_repo_name(config.rpm_repository_prefix, rpm_name)
+    name = _to_rpm_repo_name(config.rpm_repository_prefix, id)
     if name in registered_rpms:
         return False
     registered_rpms[name] = 1

--- a/cmd/config_helper.go
+++ b/cmd/config_helper.go
@@ -56,6 +56,7 @@ func toConfig(install, forceIgnored []*api.Package, targets []string, cmdline []
 		}
 
 		allPackages[installPackage] = &bazeldnf.RPM{
+			Id:           makeId(installPackage),
 			Name:         installPackage.Name,
 			Integrity:    integrity,
 			URLs:         []string{installPackage.Location.Href},

--- a/cmd/config_helper_test.go
+++ b/cmd/config_helper_test.go
@@ -122,6 +122,7 @@ func newSimpleRPM(name string, deps ...string) *bazeldnf.RPM {
 	}
 
 	return &bazeldnf.RPM{
+		Id:           name,
 		Name:         name,
 		URLs:         []string{""},
 		Integrity:    "sha256-",
@@ -155,6 +156,7 @@ func TestConfigTransform(t *testing.T) {
 			},
 			expectedRPMs: []*bazeldnf.RPM{
 				&bazeldnf.RPM{
+					Id:           "package0",
 					Name:         "package0",
 					Integrity:    "sha256-+HtJxReqyetIkKS1AFvMSlhnSPJ2DqEQY4LziXEppg4=",
 					URLs:         []string{"urlforrpm"},
@@ -188,6 +190,7 @@ func TestConfigTransform(t *testing.T) {
 			},
 			expectedRPMs: []*bazeldnf.RPM{
 				&bazeldnf.RPM{
+					Id:           "package0",
 					Name:         "package0",
 					Integrity:    "sha256-+HtJxReqyetIkKS1AFvMSlhnSPJ2DqEQY4LziXEppg4=",
 					URLs:         []string{"urlforrpm"},
@@ -195,6 +198,7 @@ func TestConfigTransform(t *testing.T) {
 					Dependencies: []string{},
 				},
 				&bazeldnf.RPM{
+					Id:           "package1",
 					Name:         "package1",
 					Integrity:    "sha256-kUagLtko/8pu8PEkHS2G5OmY5vcKrodXVGAf2lSVH70=",
 					URLs:         []string{"urlforrpm0"},
@@ -227,6 +231,7 @@ func TestConfigTransform(t *testing.T) {
 			},
 			expectedRPMs: []*bazeldnf.RPM{
 				&bazeldnf.RPM{
+					Id:           "package0",
 					Name:         "package0",
 					Integrity:    "sha256-+HtJxReqyetIkKS1AFvMSlhnSPJ2DqEQY4LziXEppg4=",
 					URLs:         []string{"urlforrpm"},
@@ -234,6 +239,7 @@ func TestConfigTransform(t *testing.T) {
 					Dependencies: []string{},
 				},
 				&bazeldnf.RPM{
+					Id:           "package1",
 					Name:         "package1",
 					Integrity:    "sha256-kUagLtko/8pu8PEkHS2G5OmY5vcKrodXVGAf2lSVH70=",
 					URLs:         []string{"urlforrpm0"},

--- a/pkg/api/bazeldnf/config.go
+++ b/pkg/api/bazeldnf/config.go
@@ -1,6 +1,7 @@
 package bazeldnf
 
 type RPM struct {
+	Id           string   `json:"id"`
 	Name         string   `json:"name"`
 	Integrity    string   `json:"integrity"`
 	URLs         []string `json:"urls"`


### PR DESCRIPTION
PR #172 introduced a unique identifier for RPMs to facilitate internal data storage during config generation.

As motivated previously: the package name alone is insufficient as a unique identifier in view of proposal #166. Consequently, the internal identifier must be materialised in the configuration file to allow consistent RPM identification.

This change adds an `Id` field to the lockfile.
The repository extension is updated to prefer this new id field while falling back to name for backward compatibility with older lockfiles.

The logic currently remains functionally equivalent, as the id generation continues to mirror the package name.