### PR TITLE
Delegate alias generation to macro

### DIFF
--- a/bazeldnf/BUILD.bazel
+++ b/bazeldnf/BUILD.bazel
@@ -17,6 +17,15 @@ resolved_bazeldnf_toolchain(
 )
 
 bzl_library(
+    name = "alias_macros",
+    srcs = ["alias_macros.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//internal:rpm",
+    ],
+)
+
+bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],

--- a/bazeldnf/alias_macros.bzl
+++ b/bazeldnf/alias_macros.bzl
@@ -1,0 +1,43 @@
+""" Strategies for alias generation in alias repository """
+
+load("@bazeldnf//internal:rpm.bzl", "null_rpm_rule")
+
+def default(name, rpms, visibility = ["//visibility:public"]):
+    """
+    Default behaviour for alias generation.
+
+    Everything depends on how many times was the given package resolved ("installed"):
+     0 – it was requested, but not resolved – return empty providers
+     1 – resolved – package available under its name
+    >1 – resolved in multiple architectures (not supported at the moment)
+
+    Args:
+      name: default target name
+      rpms: list of RPM metadata; each one is a dict consisting of:
+        package (optional), id, repo_name
+        Consult `bazeldnf/extension.bzl`'s `packages_metadata` variable for more datails.
+      visibility: visibility for aliases
+    """
+
+    def alias(name, rpm):
+        native.alias(
+            name = name,
+            actual = "@{}//rpm".format(rpm["repo_name"]),
+            visibility = visibility,
+        )
+
+    if len(rpms) > 1:
+        fail("Package resolved multiple times, not implemented.")
+
+    if len(rpms) == 1:
+        rpm = rpms[0]
+        alias(
+            name = name,
+            rpm = rpm,
+        )
+
+    if len(rpms) == 0:
+        null_rpm_rule(
+            name = name,
+            visibility = visibility,
+        )

--- a/internal/rpm.bzl
+++ b/internal/rpm.bzl
@@ -133,22 +133,3 @@ def _null_rpm_rule_impl(_):
 null_rpm_rule = rule(
     implementation = _null_rpm_rule_impl,
 )
-
-_NULL_FILE_BUILD = """
-load("@bazeldnf//internal:rpm.bzl", "null_rpm_rule")
-package(default_visibility = ["//visibility:public"])
-null_rpm_rule(
-    name = "rpm",
-)
-"""
-
-def _null_rpm_impl(ctx):
-    ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))
-    ctx.file(
-        "rpm/BUILD",
-        _NULL_FILE_BUILD,
-    )
-
-null_rpm = repository_rule(
-    implementation = _null_rpm_impl,
-)


### PR DESCRIPTION
To support the multi-arch proposal #166, the extension requires more sophisticated logic for the alias repository, particularly when a single package resolves to multiple RPMs (e.g. for different architectures).

Previously, the repository rule was responsible for the textual construction of alias target in the generated BUILD file. This approach is rigid and scales poorly when complex logic to handle more aliases is required. By extracting this logic into a dedicated macro, the repository rule is responsible only for providing structured metadata about RPMs. The logic determining how to expose that data (as an alias, a null rule, or perhaps a `select` in the future) is deferred to the macro. This decouples data resolution from target generation and allows utilizing more the expressiveness of Starlark.

This implementation tries to provide the equivalent logic as before. Minor changes include:
- if an RPM repository was generated for other config, now the alias will be correctly generated (metadata is fetched from previous config via the `registered_rpms` shared dict);
- not creating `null_rpm_repository` as alias generator macro can call `null_rpm_rule` directly.

This structure allows for future customisation, where users could potentially provide their own alias generation strategies if the default one doesn't fit their needs.