### PR TITLE
Add `Resource` abstraction to the SAT loader

### DIFF
--- a/pkg/sat/sat.go
+++ b/pkg/sat/sat.go
@@ -18,8 +18,7 @@ type VarType string
 
 const (
 	VarTypePackage  = "Package"
-	VarTypeResource = "Resource"
-	VarTypeFile     = "File"
+	VarTypeResource = "Resource" // includes files
 )
 
 // VarContext contains all information to create a unique identifyable hash key which can be traced back to a package


### PR DESCRIPTION
[ A small extract from a larger change #153 ]

---

Variable generation is separated into two parts:
- extracting `Resource`s provided by the package – data most useful for the `Loader`;
- creating SAT variable related to that resource – data most useful for the `Resolve` (`Model`).

This modularization of code should facilitates future code changes.

The `VarTypeResource` vs. `VarTypeFile` distinction was not used, therefore these were merged for further simplification.