### PR TITLE
Remove sorting vars through `VarContext`

### DIFF
--- a/pkg/sat/sat.go
+++ b/pkg/sat/sat.go
@@ -11,7 +11,6 @@ import (
 	"github.com/crillab/gophersat/bf"
 	"github.com/crillab/gophersat/maxsat"
 	"github.com/rmohr/bazeldnf/pkg/api"
-	"github.com/rmohr/bazeldnf/pkg/rpm"
 	"github.com/sirupsen/logrus"
 )
 
@@ -28,10 +27,6 @@ const (
 type VarContext struct {
 	PackageKey api.PackageKey
 	Provides   string
-}
-
-func varContextSort(a VarContext, b VarContext) int {
-	return rpm.ComparePackageKey(a.PackageKey, b.PackageKey)
 }
 
 type Var struct {


### PR DESCRIPTION
[ A small extract from a larger change #153 ]

---

The purpose of the code removed in this change was to keep the iteration over `pkgProvideKeys` stable for deterministic SAT formulation.
This can be achieved easier – `packages` already have deterministic order and also `explodePackageToVars` is deterministic. Therefore the dependency on `VarContext` can be removed and code simplified.