### PR TITLE
Include package architecture in the pinning key 

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"cmp"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/xml"
@@ -339,6 +340,29 @@ type PackageKey struct {
 
 func (p *Package) Key() PackageKey {
 	return PackageKey{p.Name, p.Version, p.Arch}
+}
+
+// InstallKey identifies a package and can be used as a map key.
+// It should be equal iff. we believe two packages cannot be installed simultaneously
+// (e.g. different version of the same package).
+// It groups packages for the purpose of `--nobest` option disabled,
+// so that for each set of packages sharing this key, only the "best" package will be preserved
+// (best in terms of repo priority, version criteria).
+type InstallKey struct {
+	Name string
+	Arch string
+}
+
+// CompareInstallKey provides an arbitrary, deterministic, total order on BestKey
+func CompareInstallKey(k1 InstallKey, k2 InstallKey) int {
+	return cmp.Or(
+		cmp.Compare(k1.Name, k2.Name),
+		cmp.Compare(k1.Arch, k2.Arch),
+	)
+}
+
+func (p *Package) InstallKey() InstallKey {
+	return InstallKey{Name: p.Name, Arch: p.Arch}
 }
 
 type Repository struct {

--- a/pkg/reducer/reducer.go
+++ b/pkg/reducer/reducer.go
@@ -45,7 +45,7 @@ func packageMatchesString(pkg *api.Package, req string) bool {
 func (r *RepoReducer) Resolve(packages []string, ignoreMissing bool) (matched []string, involved []*api.Package, err error) {
 	packages = append(packages, r.implicitRequires...)
 	discovered := map[api.PackageKey]*api.Package{}
-	pinned := map[string]*api.Package{}
+	pinned := map[api.InstallKey]*api.Package{}
 	for _, req := range packages {
 		found := false
 		name := ""
@@ -81,7 +81,7 @@ func (r *RepoReducer) Resolve(packages []string, ignoreMissing bool) (matched []
 	}
 
 	for _, v := range discovered {
-		pinned[v.Name] = v
+		pinned[v.InstallKey()] = v
 	}
 
 	for {
@@ -92,7 +92,7 @@ func (r *RepoReducer) Resolve(packages []string, ignoreMissing bool) (matched []
 		for _, p := range current {
 			for _, newFound := range r.requires(discovered[p]) {
 				if _, exists := discovered[newFound.Key()]; !exists {
-					if pinnedPkg, exists := pinned[newFound.Name]; !exists {
+					if pinnedPkg, exists := pinned[newFound.InstallKey()]; !exists {
 						discovered[newFound.Key()] = newFound
 					} else {
 						logrus.Debugf("excluding %s because of pinned dependency %s", newFound.String(), pinnedPkg.String())

--- a/pkg/reducer/reducer.go
+++ b/pkg/reducer/reducer.go
@@ -92,10 +92,10 @@ func (r *RepoReducer) Resolve(packages []string, ignoreMissing bool) (matched []
 		for _, p := range current {
 			for _, newFound := range r.requires(discovered[p]) {
 				if _, exists := discovered[newFound.Key()]; !exists {
-					if _, exists := pinned[newFound.Name]; !exists {
+					if pinnedPkg, exists := pinned[newFound.Name]; !exists {
 						discovered[newFound.Key()] = newFound
 					} else {
-						logrus.Debugf("excluding %s because of pinned dependency %s", newFound.String(), pinned[newFound.Name].String())
+						logrus.Debugf("excluding %s because of pinned dependency %s", newFound.String(), pinnedPkg.String())
 					}
 				}
 			}

--- a/pkg/reducer/reducer_test.go
+++ b/pkg/reducer/reducer_test.go
@@ -338,3 +338,31 @@ func TestSpecifyArch(t *testing.T) {
 	g.Expect(matched).Should(ConsistOf("foo", "bar"))
 	g.Expect(involved).Should(ConsistOf(&packages[0], &packages[3]))
 }
+
+func TestPinningArchExplicit(t *testing.T) {
+	// Requesting a package with a given architecture should not prevent
+	// involvement of other architectures, if needed.
+	g := NewGomegaWithT(t)
+	packages := withRepository([]api.Package{
+		newPackageWithDeps("foo", []string{"bar"}, nil),
+		newPackage("foo"),
+		newPackage("foo"),
+		newPackageWithDeps("bar", []string{"/foo.ppc"}, nil),
+	})
+	packages[0].Arch = "x86_64"
+	packages[1].Arch = "aarch64"
+	packages[2].Arch = "ppc"
+	packages[3].Arch = "noarch"
+	packageInfo := packageInfo{
+		packages: packages,
+		provides: map[string][]*api.Package{
+			"/foo.ppc": {&packages[2]},
+			"bar":      {&packages[3]},
+		},
+	}
+
+	matched, involved, err := resolve(&packageInfo, []string{"foo.x86_64"}, []string{}, false)
+	g.Expect(err).Should(BeNil())
+	g.Expect(matched).Should(ConsistOf("foo"))
+	g.Expect(involved).Should(ConsistOf(&packages[0], &packages[2], &packages[3]))
+}

--- a/pkg/sat/loader.go
+++ b/pkg/sat/loader.go
@@ -1,7 +1,6 @@
 package sat
 
 import (
-	"cmp"
 	"fmt"
 	"regexp"
 	"sort"
@@ -23,32 +22,12 @@ type Loader struct {
 	varsCount int
 }
 
-// BestKey groups packages for the purpose of `--nobest` option disabled,
-// so that for each set of packages sharing this key, only the "best" package will be preserved
-// (best in terms of repo priority, version criteria).
-type BestKey struct {
-	name string
-	arch string
-}
-
-// CompareBestKey provides an arbitrary, deterministic, total order on BestKey
-func CompareBestKey(k1 BestKey, k2 BestKey) int {
-	return cmp.Or(
-		cmp.Compare(k1.name, k2.name),
-		cmp.Compare(k1.arch, k2.arch),
-	)
-}
-
-func MakeBestKey(pkg *api.Package) BestKey {
-	return BestKey{name: pkg.Name, arch: pkg.Arch}
-}
-
 func NewLoader() *Loader {
 	return &Loader{
 		m: &Model{
 			packages:                    map[string][]*Var{},
 			vars:                        map[string]*Var{},
-			bestPackages:                map[BestKey]*api.Package{},
+			bestPackages:                map[api.InstallKey]*api.Package{},
 			forceIgnoreWithDependencies: map[api.PackageKey]*api.Package{},
 		},
 		provides:  map[string][]*Var{},
@@ -126,7 +105,7 @@ func (loader *Loader) Load(packages []*api.Package, matched, ignoreRegex, allowR
 
 	// Create an index to pick the best candidates
 	for _, pkg := range packages {
-		key := MakeBestKey(pkg)
+		key := pkg.InstallKey()
 		if loader.m.bestPackages[key] == nil {
 			loader.m.bestPackages[key] = pkg
 		} else if rpm.ComparePackage(pkg, loader.m.bestPackages[key], archOrder) > 0 {
@@ -137,7 +116,7 @@ func (loader *Loader) Load(packages []*api.Package, matched, ignoreRegex, allowR
 	if !nobest {
 		packages = nil
 		bestPackagesKeys := maps.Keys(loader.m.bestPackages)
-		slices.SortFunc(bestPackagesKeys, CompareBestKey)
+		slices.SortFunc(bestPackagesKeys, api.CompareInstallKey)
 		for _, v := range bestPackagesKeys {
 			packages = append(packages, loader.m.bestPackages[v])
 		}

--- a/pkg/sat/loader_test.go
+++ b/pkg/sat/loader_test.go
@@ -38,7 +38,7 @@ func expectedBest(g *WithT, m *Model, pkgVersions map[string]string) {
 	g.Expect(m.bestPackages).To(HaveLen(len(pkgVersions)))
 
 	for k, version := range pkgVersions {
-		g.Expect(m.bestPackages[BestKey{name: k}].Version.String()).To(Equal(version))
+		g.Expect(m.bestPackages[api.InstallKey{Name: k}].Version.String()).To(Equal(version))
 	}
 }
 

--- a/pkg/sat/sat.go
+++ b/pkg/sat/sat.go
@@ -48,7 +48,7 @@ type Model struct {
 	// vars contain as key an exact identifier for a provided resource and the actual SAT variable as value
 	vars map[string]*Var
 
-	bestPackages map[BestKey]*api.Package
+	bestPackages map[api.InstallKey]*api.Package
 
 	ands                        []bf.Formula
 	forceIgnoreWithDependencies map[api.PackageKey]*api.Package
@@ -62,7 +62,7 @@ func (m *Model) Var(v string) *Var {
 	return m.vars[v]
 }
 
-func (m *Model) BestPackage(k BestKey) *api.Package {
+func (m *Model) BestPackage(k api.InstallKey) *api.Package {
 	return m.bestPackages[k]
 }
 
@@ -193,7 +193,7 @@ func Resolve(model *Model) (install []*api.Package, excluded []*api.Package, for
 			}
 		}
 		for v := range installSet {
-			key := MakeBestKey(v)
+			key := v.InstallKey()
 			bestPackage := model.BestPackage(key)
 			if bestPackage != v {
 				logrus.Infof("Picking %v instead of best candiate %v", v, bestPackage)


### PR DESCRIPTION
The pinning logic prevents the discovery of similar packages,
effectively freezing the set of involved packages within a given package name
to the ones that match requests in the `packages` argument to the `Resolve`.

Previously, the pinning mechanism used the package name as its sole key.
When a user requested a specific architecture for a package, the resolver was artificially blocked from discovering other architectures of that exact same package.
This occurred even when those alternative architectures were mandated by standard dependency relations, effectively breaking the resolution graph for multilib or cross-compiled environments.

This change replaces the raw package name with the installation key,
which incorporates both the name and the architecture, as the primary domain for pinning.
Pinning will still prevent discovering alternative versions (if a particular version was explicitly requested).

This also matches more closely [the `dnf` behaviour](https://github.com/aszady/dnfexplore/blob/8ef18cf4bb63042aca37af2026d486b3d6c4afd1/readme.md?plain=1#L310-L335).