### PR TITLE
rpm: handle usrmerge paths in tar2files

### DIFF
--- a/pkg/rpm/tar.go
+++ b/pkg/rpm/tar.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -14,6 +15,13 @@ import (
 	"github.com/sassoftware/go-rpmutils/cpio"
 	log "github.com/sirupsen/logrus"
 )
+
+var usrMergeAliases = map[string]string{
+	"/bin":   "/usr/bin",
+	"/lib":   "/usr/lib",
+	"/lib64": "/usr/lib64",
+	"/sbin":  "/usr/sbin",
+}
 
 type Collector struct {
 	createdPaths map[string]struct{}
@@ -49,8 +57,41 @@ func RPMToCPIO(rpmReader io.Reader) (*cpio.CpioStream, error) {
 	return cpio.NewCpioStream(payloadReader), nil
 }
 
+func normalizeTarPath(name string) string {
+	name = strings.TrimPrefix(name, "./")
+	name = strings.TrimPrefix(name, "/")
+	return path.Clean("/" + name)
+}
+
+func detectUsrMergeAlias(name, linkname string) (string, bool) {
+	expectedTarget, exists := usrMergeAliases[name]
+	if !exists {
+		return "", false
+	}
+
+	return expectedTarget, normalizeTarPath(linkname) == expectedTarget
+}
+
+func normalizeUsrMergePath(prefix, name string, aliases map[string]string) string {
+	for alias, target := range aliases {
+		if prefix != target && !strings.HasPrefix(prefix, target+"/") {
+			continue
+		}
+
+		if name == alias {
+			return target
+		}
+
+		if strings.HasPrefix(name, alias+"/") {
+			return target + strings.TrimPrefix(name, alias)
+		}
+	}
+
+	return name
+}
+
 func PrefixFilter(prefix, strip string, reader *tar.Reader, files []string) error {
-	prefix = strings.TrimPrefix(prefix, ".")
+	prefix = normalizeTarPath(prefix)
 
 	fileMap := map[string]string{}
 	for _, file := range files {
@@ -67,11 +108,13 @@ func PrefixFilter(prefix, strip string, reader *tar.Reader, files []string) erro
 		if !strings.HasPrefix(key, "/") {
 			key = "/" + key
 		}
+		key = path.Clean(key)
 
 		log.Tracef("Mapped file %v -> %v", key, file)
 		fileMap[key] = file
 	}
 
+	aliases := map[string]string{}
 	for {
 		entry, err := reader.Next()
 		if err == io.EOF {
@@ -80,10 +123,12 @@ func PrefixFilter(prefix, strip string, reader *tar.Reader, files []string) erro
 		if len(fileMap) == 0 {
 			break
 		}
-		name := strings.TrimPrefix(entry.Name, ".")
-		if strings.HasPrefix(name, prefix) {
-		} else if prefix == "/usr/lib64" && strings.HasPrefix(name, "/lib64") {
-		} else {
+		name := normalizeTarPath(entry.Name)
+		if target, ok := detectUsrMergeAlias(name, entry.Linkname); ok && entry.Typeflag == tar.TypeSymlink {
+			aliases[name] = target
+		}
+		name = normalizeUsrMergePath(prefix, name, aliases)
+		if !strings.HasPrefix(name, prefix) {
 			continue
 		}
 

--- a/pkg/rpm/tar_test.go
+++ b/pkg/rpm/tar_test.go
@@ -2,6 +2,7 @@ package rpm
 
 import (
 	"archive/tar"
+	"bytes"
 	"io"
 	"io/ioutil"
 	"os"
@@ -245,6 +246,82 @@ func TestTar2Files(t *testing.T) {
 			g.Expect(discoveredHeaders).To(ConsistOf(tt.expected))
 		})
 	}
+}
+
+func TestTar2FilesHandlesUsrMergePaths(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var archive bytes.Buffer
+	tarWriter := tar.NewWriter(&archive)
+	writeEntry := func(header *tar.Header, content string) {
+		g.Expect(tarWriter.WriteHeader(header)).To(Succeed())
+		if header.Typeflag == tar.TypeReg {
+			_, err := tarWriter.Write([]byte(content))
+			g.Expect(err).ToNot(HaveOccurred())
+		}
+	}
+
+	writeEntry(&tar.Header{Name: "./usr", Typeflag: tar.TypeDir, Mode: 0755}, "")
+	writeEntry(&tar.Header{Name: "./usr/lib64", Typeflag: tar.TypeDir, Mode: 0755}, "")
+	writeEntry(&tar.Header{Name: "./lib64", Typeflag: tar.TypeSymlink, Linkname: "usr/lib64", Mode: 0777}, "")
+	writeEntry(&tar.Header{Name: "./lib64/libexample.so.1.0", Typeflag: tar.TypeReg, Mode: 0644, Size: 6}, "binary")
+	writeEntry(&tar.Header{Name: "./lib64/libexample.so.1", Typeflag: tar.TypeSymlink, Linkname: "libexample.so.1.0", Mode: 0777}, "")
+	g.Expect(tarWriter.Close()).To(Succeed())
+
+	tmpdir, err := ioutil.TempDir("", "usrmerge")
+	g.Expect(err).ToNot(HaveOccurred())
+	defer os.RemoveAll(tmpdir)
+
+	files := []string{}
+	for _, file := range []string{"/usr/lib64/libexample.so.1.0", "/usr/lib64/libexample.so.1"} {
+		err = os.MkdirAll(filepath.Join(tmpdir, filepath.Dir(file)), 0777)
+		g.Expect(err).ToNot(HaveOccurred())
+		files = append(files, filepath.Join(tmpdir, file))
+	}
+
+	err = PrefixFilter("./usr/lib64", tmpdir, tar.NewReader(bytes.NewReader(archive.Bytes())), files)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	discoveredHeaders, err := collectFileInfo(tmpdir)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(discoveredHeaders).To(ConsistOf([]fileInfo{
+		{Name: "usr", Children: []fileInfo{
+			{Name: "lib64", Children: []fileInfo{
+				{Name: "libexample.so.1", Size: 17, Link: "libexample.so.1.0"},
+				{Name: "libexample.so.1.0", Size: 6},
+			}},
+		}},
+	}))
+}
+
+func TestTar2FilesDoesNotAliasWithoutUsrMergeSymlink(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var archive bytes.Buffer
+	tarWriter := tar.NewWriter(&archive)
+	g.Expect(tarWriter.WriteHeader(&tar.Header{
+		Name:     "./lib64/libexample.so.1.0",
+		Typeflag: tar.TypeReg,
+		Mode:     0644,
+		Size:     6,
+	})).To(Succeed())
+	_, err := tarWriter.Write([]byte("binary"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(tarWriter.Close()).To(Succeed())
+
+	tmpdir, err := ioutil.TempDir("", "usrmerge-negative")
+	g.Expect(err).ToNot(HaveOccurred())
+	defer os.RemoveAll(tmpdir)
+
+	file := "/usr/lib64/libexample.so.1.0"
+	err = os.MkdirAll(filepath.Join(tmpdir, filepath.Dir(file)), 0777)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = PrefixFilter("./usr/lib64", tmpdir, tar.NewReader(bytes.NewReader(archive.Bytes())), []string{
+		filepath.Join(tmpdir, file),
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("could not be found"))
 }
 
 func collectFileInfo(dirName string) ([]fileInfo, error) {


### PR DESCRIPTION
Normalize tar entries like /lib64 to /usr/lib64 only when the archive declares the matching usrmerge symlink. This fixes CentOS-style RPM payloads without changing behaviour for non-usrmerge archives.

This was hit in testing with newer bazeldnf versions in kubevirt where the following workaround also worked:
https://github.com/kubevirt/kubevirt/pull/17710/changes/0072d287e3d854f8162ce4e5f48ffe4c0008c736