### PR TITLE
Retry file transfers on transient network errors

### DIFF
--- a/pkg/repo/BUILD.bazel
+++ b/pkg/repo/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     embed = [":repo"],
     deps = [
         "//pkg/api",
+        "//pkg/api/bazeldnf",
         "@com_github_hashicorp_go_retryablehttp//:go-retryablehttp",
     ],
 )

--- a/pkg/repo/cache.go
+++ b/pkg/repo/cache.go
@@ -93,16 +93,16 @@ func (r *CacheHelper) WriteToRepoDir(repo *bazeldnf.Repository, body io.Reader, 
 
 	err := os.MkdirAll(dir, 0770)
 	if err != nil && !os.IsExist(err) {
-		return fmt.Errorf("failed to create cache directory for %s: %v", repo.Name, err)
+		return fmt.Errorf("failed to create cache directory for %s: %w", repo.Name, err)
 	}
 	f, err := os.Create(file)
 	if err != nil {
-		return fmt.Errorf("failed to open file %s: %v", file, err)
+		return fmt.Errorf("failed to open file %s: %w", file, err)
 	}
 	defer f.Close()
 	_, err = io.Copy(f, body)
 	if err != nil {
-		return fmt.Errorf("failed to write file %s: %v", file, err)
+		return fmt.Errorf("failed to write file %s: %w", file, err)
 	}
 	return nil
 }

--- a/pkg/repo/fetch.go
+++ b/pkg/repo/fetch.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/jdx/go-netrc"
@@ -176,6 +177,8 @@ func (r *RepoFetcherImpl) resolveRepomd(repo *bazeldnf.Repository, repomdURLs []
 	return repomd, mirror, nil
 }
 
+const transferRetries = 3
+
 func (r *RepoFetcherImpl) fetchFile(fileType string, repo *bazeldnf.Repository, repomd *api.Repomd, mirror *url.URL) (err error) {
 	file := repomd.File(fileType)
 	if file == nil {
@@ -192,31 +195,58 @@ func (r *RepoFetcherImpl) fetchFile(fileType string, repo *bazeldnf.Repository, 
 		mirrorCopy.Path = path.Join(mirror.Path, file.Location.Href)
 		fileURL = mirrorCopy.String()
 	}
+
+	var lastErr error
+	for attempt := range transferRetries + 1 {
+		if attempt > 0 {
+			log.Warnf("Retrying %s file transfer from %s (attempt %d/%d): %v", fileType, fileURL, attempt+1, transferRetries+1, lastErr)
+		}
+
+		retryable, err := r.doTransfer(fileType, fileURL, fileName, repo, file)
+		if err == nil {
+			return nil
+		}
+		if !retryable {
+			return err
+		}
+		lastErr = err
+	}
+	return lastErr
+}
+
+func (r *RepoFetcherImpl) doTransfer(fileType, fileURL, fileName string, repo *bazeldnf.Repository, file *api.Data) (retryable bool, _ error) {
 	log.Infof("Loading %s file from %s", fileType, fileURL)
 	resp, err := r.Getter.Get(fileURL)
 	if err != nil {
-		return fmt.Errorf("Failed to load primary repository file from %s: %v", fileURL, err)
+		// Getter.Get uses retryablehttp internally; if it failed, retries are already exhausted.
+		return false, fmt.Errorf("Failed to load primary repository file from %s: %v", fileURL, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return fmt.Errorf("Failed to download %s: %v ", fileURL, fmt.Errorf("status : %v", resp.StatusCode))
+		return false, fmt.Errorf("Failed to download %s: %v ", fileURL, fmt.Errorf("status : %v", resp.StatusCode))
 	}
 	sha, shasum, err := chooseHashType(file)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	body := io.TeeReader(resp.Body, sha)
 	err = r.CacheHelper.WriteToRepoDir(repo, body, fileName)
 	if err != nil {
-		return fmt.Errorf("Failed to write file.xml from %s to file: %v", fileURL, err)
+		return isTransientTransferError(err), fmt.Errorf("Failed to write file.xml from %s to file: %v", fileURL, err)
 	}
 
 	if shasum != toHex(sha) {
-		return fmt.Errorf("Expected sha sum %s, but got %s", shasum, toHex(sha))
+		return false, fmt.Errorf("Expected sha sum %s, but got %s", shasum, toHex(sha))
 	}
 
-	return nil
+	return false, nil
+}
+
+func isTransientTransferError(err error) bool {
+	return errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNABORTED)
 }
 
 type Getter interface {

--- a/pkg/repo/fetch_test.go
+++ b/pkg/repo/fetch_test.go
@@ -2,17 +2,24 @@ package repo
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/rmohr/bazeldnf/pkg/api"
+	"github.com/rmohr/bazeldnf/pkg/api/bazeldnf"
 )
 
 const retryAttempts = 5
@@ -159,4 +166,139 @@ password %s`, user, password)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("We've set NETRC so the server should reply with 200 but got %d", resp.StatusCode)
 	}
+}
+
+func newPassthroughClient() *retryablehttp.Client {
+	c := retryablehttp.NewClient()
+	c.RetryMax = 0
+	c.ErrorHandler = retryablehttp.PassthroughErrorHandler
+	return c
+}
+
+func hijackConnection(t *testing.T, rw http.ResponseWriter) net.Conn {
+	t.Helper()
+	hj, ok := rw.(http.Hijacker)
+	if !ok {
+		t.Fatal("server doesn't support hijacking")
+	}
+	conn, bufrw, err := hj.Hijack()
+	if err != nil {
+		t.Fatalf("hijack: %v", err)
+	}
+	bufrw.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 10000\r\n\r\npartial")
+	bufrw.Flush()
+	return conn
+}
+
+func newTestFetcher(serverURL, cacheDir string) (*RepoFetcherImpl, *url.URL) {
+	mirror, _ := url.Parse(serverURL + "/repo/")
+	return &RepoFetcherImpl{
+		Getter:      &getterImpl{client: newPassthroughClient()},
+		CacheHelper: NewCacheHelper(cacheDir),
+	}, mirror
+}
+
+func TestFetchFileRetry(t *testing.T) {
+	content := []byte("test repository content")
+	sum := sha256.Sum256(content)
+	checksum := hex.EncodeToString(sum[:])
+
+	repomd := func() *api.Repomd {
+		d := api.Data{}
+		d.Type = api.PrimaryFileType
+		d.Checksum.Text = checksum
+		d.Checksum.Type = "sha256"
+		d.Location.Href = "repodata/primary.xml.gz"
+		return &api.Repomd{Data: []api.Data{d}}
+	}()
+
+	repo := &bazeldnf.Repository{Name: "test-repo"}
+
+	transferErrors := []struct {
+		error     string
+		closeConn func(net.Conn)
+	}{
+		{"unexpected EOF", func(c net.Conn) { c.Close() }},
+		{"connection reset", func(c net.Conn) { c.(*net.TCPConn).SetLinger(0); c.Close() }},
+	}
+
+	for _, tc := range transferErrors {
+		t.Run("retries on "+tc.error, func(t *testing.T) {
+			calls := 0
+			s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				calls++
+				if calls == 1 {
+					tc.closeConn(hijackConnection(t, rw))
+					return
+				}
+				rw.Write(content)
+			}))
+			defer s.Close()
+
+			fetcher, mirror := newTestFetcher(s.URL, t.TempDir())
+			if err := fetcher.fetchFile(api.PrimaryFileType, repo, repomd, mirror); err != nil {
+				t.Fatalf("expected success after retry, got: %v", err)
+			}
+			if calls != 2 {
+				t.Fatalf("expected 2 calls, got %d", calls)
+			}
+		})
+	}
+
+	for _, tc := range transferErrors {
+		t.Run("exhausted retries on "+tc.error, func(t *testing.T) {
+			calls := 0
+			s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				calls++
+				tc.closeConn(hijackConnection(t, rw))
+			}))
+			defer s.Close()
+
+			fetcher, mirror := newTestFetcher(s.URL, t.TempDir())
+			err := fetcher.fetchFile(api.PrimaryFileType, repo, repomd, mirror)
+			if err == nil {
+				t.Fatal("expected error after exhausted retries, got nil")
+			}
+			if calls != transferRetries+1 {
+				t.Fatalf("expected %d calls, got %d", transferRetries+1, calls)
+			}
+			if !strings.Contains(err.Error(), tc.error) {
+				t.Fatalf("expected error to mention %q, got: %v", tc.error, err)
+			}
+		})
+	}
+
+	t.Run("no retry on 4xx", func(t *testing.T) {
+		calls := 0
+		s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			calls++
+			rw.WriteHeader(http.StatusNotFound)
+		}))
+		defer s.Close()
+
+		fetcher, mirror := newTestFetcher(s.URL, t.TempDir())
+		if err := fetcher.fetchFile(api.PrimaryFileType, repo, repomd, mirror); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if calls != 1 {
+			t.Fatalf("expected 1 call (no retry), got %d", calls)
+		}
+	})
+
+	t.Run("no retry on filesystem error", func(t *testing.T) {
+		calls := 0
+		s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			calls++
+			rw.Write(content)
+		}))
+		defer s.Close()
+
+		fetcher, mirror := newTestFetcher(s.URL, "/dev/null/impossible")
+		if err := fetcher.fetchFile(api.PrimaryFileType, repo, repomd, mirror); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if calls != 1 {
+			t.Fatalf("expected 1 call (no retry), got %d", calls)
+		}
+	})
 }


### PR DESCRIPTION
Repository metadata files are susceptible to mid-transfer failures: the download might take long enough for the network infrastucture to time out or for other transient network issues to surface. These are inherently retriable – the server has the file, the connection just dropped.

`fetchFile` now wraps the transfer in a retry loop (up to 3 retries). Only genuinely transient errors trigger a retry.
HTTP status codes and `Getter.Get` failures are not retried at this layer – `retryablehttp` handles those internally, and by the time an error reaches `fetchFile`, those retries are already exhausted.

`WriteToRepoDir` error wrapping is changed from `%v` to `%w` so that `errors.Is` can see through to the underlying cause when classifying errors.